### PR TITLE
Fix installation process

### DIFF
--- a/userfrosting/middleware/usersession/UserSession.php
+++ b/userfrosting/middleware/usersession/UserSession.php
@@ -91,8 +91,10 @@ class UserSession extends \Slim\Middleware {
             // If we can't connect to the DB, then we can't create an authenticated user.  That's ok if we're in installation mode.
             error_log("Unable to authenticate user because the database is not yet initialized, invalid, or inaccessible.  Falling back to guest user.");
             error_log($e->getTraceAsString());
-            $controller = new BaseController($this->app);
-            return $controller->pageDatabaseError();
+			
+			// How can we tell we are not in installation mode? Until then, the following code is just staged.
+            // $controller = new BaseController($this->app);
+            // return $controller->pageDatabaseError();
         }
     }
 }


### PR DESCRIPTION
This fixes an issue with the installation process. If database is not yet set up we are guaranteed a PDO exception. Without knowing if we are installation mode or not we can't be sure if we should show a database error page or just continue routing (ie: to the installation page). So, with this change we just continue routing. The problematic code is left as staged code, to be used if/when we can determine if we are in "installation mode" or not.