### PR TITLE
Adding comment on .env.example to save future developers time

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -1,6 +1,8 @@
+# this is a comment
+
 UF_MODE=""
 DB_DRIVER="mysql"
-DB_HOST="localhost"
+DB_HOST="localhost"  #some developer enviorments, like some MAMP installations, require you to instead set DB_HOST="127.0.0.1"
 DB_PORT="3306"
 DB_NAME="userfrosting"
 DB_USER="userfrosting"


### PR DESCRIPTION
localhost not always resolves correctly (in some MAMP installations) so adding a comment to help future developers save a days of debugging work