### PR TITLE
User must verify account again after changing email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Ignores my text editor metadata
 *.komodoproject
+*.iml
+.idea/
 
 # Ignores Mac metadata.  You can configure this globally if you use a Mac: http://islegend.com/development/setting-global-gitignore-mac-windows/
 .DS_Store
@@ -20,7 +22,7 @@ app/logs/*
 app/sessions/*
 
 # Ignore bower vendor assets
-/app/sprinkles/*/assets/vendor/
+app/sprinkles/*/assets/vendor/
 
 # Ignore sprinkles.json config file
 app/sprinkles.json

--- a/app/sprinkles/account/assets/local/pages/js/account-settings.js
+++ b/app/sprinkles/account/assets/local/pages/js/account-settings.js
@@ -14,9 +14,14 @@ $(document).ready(function() {
     $("#account-settings").ufForm({
         validators: page.validators.account_settings,
         msgTarget: $("#alerts-page")
-    }).on("submitSuccess.ufForm", function() {
-        // Reload the page on success
-        window.location.reload();
+    }).on("submitSuccess.ufForm", function(event, data, textStatus, jqXHR) {
+        if (jqXHR.getResponseHeader('UF-Redirect')) {
+            // Redirect to index page after email change
+            window.location.replace(jqXHR.getResponseHeader('UF-Redirect'));
+        } else {
+            // Reload the page on success
+            window.location.reload();
+        }
     });
 
     $("#profile-settings").ufForm({

--- a/app/sprinkles/account/templates/mail/email-change.html.twig
+++ b/app/sprinkles/account/templates/mail/email-change.html.twig
@@ -1,0 +1,17 @@
+{% block subject %}
+    {{site.title}} - email change
+{% endblock %}
+
+{% block body %}
+<p>Dear {{user.first_name}},
+</p>
+<p>
+You recently changed the email for your account with {{site.title}} ({{site.uri.public}}). Please follow the link below to verify the change and reactivate your account.
+</p>
+<a href="{{site.uri.public}}/account/verify?token={{token}}">{{site.uri.public}}/account/verify?token={{token}}</a>
+</p>
+<p>
+With regards,<br>
+The {{site.title}} Team
+</p>
+{% endblock %}

--- a/app/sprinkles/core/src/Sprunje/Sprunje.php
+++ b/app/sprinkles/core/src/Sprunje/Sprunje.php
@@ -53,6 +53,8 @@ abstract class Sprunje
      *
      * @param ClassMapper $classMapper
      * @param mixed[] $options
+     *
+     * @throws \UserFrosting\Support\Exception\BadRequestException
      */
     public function __construct($classMapper, $options)
     {
@@ -159,6 +161,7 @@ abstract class Sprunje
      *
      * Returns an array containing `count` (the total number of rows, before filtering), `count_filtered` (the total number of rows after filtering),
      * and `rows` (the filtered result set).
+     *
      * @return mixed[]
      */
     public function getResults()
@@ -196,8 +199,9 @@ abstract class Sprunje
     /**
      * Execute the query and build the results, and append them in the appropriate format to the response.
      *
-     * @param ResponseInterface $response
-     * @return ResponseInterface
+     * @param \Psr\Http\Message\ResponseInterface $response
+     *
+     * @return \UserFrosting\Support\Exception\BadRequestException
      */
     public function toResponse(Response $response)
     {
@@ -223,6 +227,8 @@ abstract class Sprunje
      * Apply any filters from the options, calling a custom filter callback when appropriate.
      *
      * @return \Illuminate\Database\Eloquent\Builder
+     *
+     * @throws \UserFrosting\Support\Exception\BadRequestException
      */
     protected function applyFilters()
     {
@@ -259,6 +265,8 @@ abstract class Sprunje
      * Apply any sorts from the options, calling a custom sorter callback when appropriate.
      *
      * @return \Illuminate\Database\Eloquent\Builder
+     *
+     * @throws \UserFrosting\Support\Exception\BadRequestException
      */
     protected function applySorts()
     {
@@ -308,6 +316,7 @@ abstract class Sprunje
      * Set any transformations you wish to apply to the collection, after the query is executed.
      *
      * @param \Illuminate\Database\Eloquent\Collection $collection
+     *
      * @return \Illuminate\Database\Eloquent\Collection
      */
     protected function applyTransformations($collection)


### PR DESCRIPTION
If the `site.registration.require_email_verification` config value is `true` the user must validate the account again after changing the email address, This prevents users from entering fake emails after the account is verified once.