### PR TITLE
Hotfix for ufTable

### DIFF
--- a/app/sprinkles/core/assets/local/core/js/uf-table.js
+++ b/app/sprinkles/core/assets/local/core/js/uf-table.js
@@ -226,7 +226,7 @@
         for (i = 0; i < sortList.length; i++) {
             var columnIndex = sortList[i][0];
             var columnDirection = sortOrders[sortList[i][1]];   // Converts to 'asc' or 'desc'
-            if (sortList[i]) {
+            if (sortList[i] === 1) {
                 var columnName = $(table.config.headerList[columnIndex]).data("column-name");
                 sorts[columnName] = columnDirection;
             }


### PR DESCRIPTION
The attribute `data-sortlist="[[0, 1]]"` should indicate wich column should be used to sort the table by default. But indeed it doesn´t as you can see in the url `../admin/activities#&sort[table-activities][occurred_at]=desc&page[table-activities]=1&size[table-activities]=10` because `occurred_at` is the first column and not the second. This PR fixes that.