### PR TITLE
Add support for other config['mailer'] options.

### DIFF
--- a/app/sprinkles/core/src/Mail/Mailer.php
+++ b/app/sprinkles/core/src/Mail/Mailer.php
@@ -44,15 +44,6 @@ class Mailer
 
         // Configuration options
         if (isset($config['mailer'])) {
-            if (!in_array($config['mailer'], ['smtp', 'mail', 'qmail', 'sendmail'])) {
-                throw new \phpmailerException("'mailer' must be one of 'smtp', 'mail', 'qmail', or 'sendmail'.");
-            }
---- a/app/sprinkles/core/src/Mail/Mailer.php
-+++ b/app/sprinkles/core/src/Mail/Mailer.php
-@@ -44,11 +44,17 @@ class Mailer
- 
-         // Configuration options
-         if (isset($config['mailer'])) {
             switch ($config['mailer']) {
             case 'mail':
                 $this->phpMailer->isMail();

--- a/app/sprinkles/core/src/Mail/Mailer.php
+++ b/app/sprinkles/core/src/Mail/Mailer.php
@@ -47,8 +47,23 @@ class Mailer
             if (!in_array($config['mailer'], ['smtp', 'mail', 'qmail', 'sendmail'])) {
                 throw new \phpmailerException("'mailer' must be one of 'smtp', 'mail', 'qmail', or 'sendmail'.");
             }
-
-            if ($config['mailer'] == 'smtp') {
+--- a/app/sprinkles/core/src/Mail/Mailer.php
++++ b/app/sprinkles/core/src/Mail/Mailer.php
+@@ -44,11 +44,17 @@ class Mailer
+ 
+         // Configuration options
+         if (isset($config['mailer'])) {
+            switch ($config['mailer']) {
+            case 'mail':
+                $this->phpMailer->isMail();
+                break;
+            case 'qmail':
+                $this->phpMailer->isQmail();
+                break;
+            case 'sendmail':
+                $this->phpMailer->isSendmail();
+                break;
+            case 'smtp':
                 $this->phpMailer->isSMTP(true);
                 $this->phpMailer->Host =       $config['host'];
                 $this->phpMailer->Port =       $config['port'];
@@ -61,6 +76,9 @@ class Mailer
                 if (isset($config['smtp_options'])) {
                     $this->phpMailer->SMTPOptions = $config['smtp_options'];
                 }
+                break;
+            default:
+                throw new \phpmailerException("'mailer' must be one of 'smtp', 'mail', 'qmail', or 'sendmail'.");
             }
 
             // Set any additional message-specific options


### PR DESCRIPTION
PHPMailer supports other mailer options such as Mail, Qmail, and sendmail.
Tested with sendmail.