### PR TITLE
rowDelete event event fix

### DIFF
--- a/app/sprinkles/core/assets/userfrosting/js/uf-collection.js
+++ b/app/sprinkles/core/assets/userfrosting/js/uf-collection.js
@@ -239,7 +239,7 @@
          */
          _deleteRow: function(row) {
              row.remove();
-             this.$element.trigger('rowDelete.ufCollection');
+             this.$element.trigger('rowDelete.ufCollection',row);
          },
          /**
          * Add delete and touch bindings for a row, increment the internal row counter, and fire the rowAdd event


### PR DESCRIPTION
The rowDelete event from the ufCollection widget didn't include the deleted row.
But following the docs it should: https://learn.userfrosting.com/client-side-code/components/collections#deleterow