### PR TITLE
Added cache control to fix bug with internet explorer not updating UF table data

### DIFF
--- a/app/sprinkles/admin/src/Controller/ActivityController.php
+++ b/app/sprinkles/admin/src/Controller/ActivityController.php
@@ -57,7 +57,8 @@ class ActivityController extends SimpleController
 
         // Be careful how you consume this data - it has not been escaped and contains untrusted user-supplied content.
         // For example, if you plan to insert it into an HTML DOM, you must escape it on the client side (or use client-side templating).
-        return $sprunje->toResponse($response);
+		//set cache headers in order to stop specially IE to cache the result
+        return $sprunje->toResponse($response)->withHeader('Cache-Control', 'no-cache')->withHeader('Expires', '-1');
     }
 
     /**

--- a/app/sprinkles/admin/src/Controller/GroupController.php
+++ b/app/sprinkles/admin/src/Controller/GroupController.php
@@ -269,7 +269,8 @@ class GroupController extends SimpleController
 
         // Be careful how you consume this data - it has not been escaped and contains untrusted user-supplied content.
         // For example, if you plan to insert it into an HTML DOM, you must escape it on the client side (or use client-side templating).
-        return $sprunje->toResponse($response);
+		//set cache headers in order to stop specially IE to cache the result
+        return $sprunje->toResponse($response)->withHeader('Cache-Control', 'no-cache')->withHeader('Expires', '-1');
     }
 
     public function getModalConfirmDelete($request, $response, $args)
@@ -474,7 +475,8 @@ class GroupController extends SimpleController
 
         // Be careful how you consume this data - it has not been escaped and contains untrusted user-supplied content.
         // For example, if you plan to insert it into an HTML DOM, you must escape it on the client side (or use client-side templating).
-        return $sprunje->toResponse($response);
+		//set cache headers in order to stop specially IE to cache the result
+        return $sprunje->toResponse($response)->withHeader('Cache-Control', 'no-cache')->withHeader('Expires', '-1');
     }
 
     /**

--- a/app/sprinkles/admin/src/Controller/PermissionController.php
+++ b/app/sprinkles/admin/src/Controller/PermissionController.php
@@ -101,7 +101,8 @@ class PermissionController extends SimpleController
 
         // Be careful how you consume this data - it has not been escaped and contains untrusted user-supplied content.
         // For example, if you plan to insert it into an HTML DOM, you must escape it on the client side (or use client-side templating).
-        return $sprunje->toResponse($response);
+		//set cache headers in order to stop specially IE to cache the result
+        return $sprunje->toResponse($response)->withHeader('Cache-Control', 'no-cache')->withHeader('Expires', '-1');
     }
 
     /**
@@ -133,8 +134,9 @@ class PermissionController extends SimpleController
         $params['permission_id'] = $args['id'];
 
         $sprunje = $classMapper->createInstance('permission_user_sprunje', $classMapper, $params);
-
-        $response = $sprunje->toResponse($response);
+		
+		//set cache headers in order to stop specially IE to cache the result
+        $response = $sprunje->toResponse($response)->withHeader('Cache-Control', 'no-cache')->withHeader('Expires', '-1');
 
         // Be careful how you consume this data - it has not been escaped and contains untrusted user-supplied content.
         // For example, if you plan to insert it into an HTML DOM, you must escape it on the client side (or use client-side templating).

--- a/app/sprinkles/admin/src/Controller/RoleController.php
+++ b/app/sprinkles/admin/src/Controller/RoleController.php
@@ -268,7 +268,8 @@ class RoleController extends SimpleController
 
         // Be careful how you consume this data - it has not been escaped and contains untrusted user-supplied content.
         // For example, if you plan to insert it into an HTML DOM, you must escape it on the client side (or use client-side templating).
-        return $sprunje->toResponse($response);
+		//set cache headers in order to stop specially IE to cache the result
+        return $sprunje->toResponse($response)->withHeader('Cache-Control', 'no-cache')->withHeader('Expires', '-1');
     }
 
     public function getModalConfirmDelete($request, $response, $args)
@@ -526,7 +527,8 @@ class RoleController extends SimpleController
 
         // Be careful how you consume this data - it has not been escaped and contains untrusted user-supplied content.
         // For example, if you plan to insert it into an HTML DOM, you must escape it on the client side (or use client-side templating).
-        return $sprunje->toResponse($response);
+		//set cache headers in order to stop specially IE to cache the result
+        return $sprunje->toResponse($response)->withHeader('Cache-Control', 'no-cache')->withHeader('Expires', '-1');
     }
 
     /**
@@ -571,7 +573,8 @@ class RoleController extends SimpleController
 
         // Be careful how you consume this data - it has not been escaped and contains untrusted user-supplied content.
         // For example, if you plan to insert it into an HTML DOM, you must escape it on the client side (or use client-side templating).
-        return $sprunje->toResponse($response);
+		//set cache headers in order to stop specially IE to cache the result
+        return $sprunje->toResponse($response)->withHeader('Cache-Control', 'no-cache')->withHeader('Expires', '-1');
     }
 
     /**

--- a/app/sprinkles/admin/src/Controller/UserController.php
+++ b/app/sprinkles/admin/src/Controller/UserController.php
@@ -342,7 +342,8 @@ class UserController extends SimpleController
 
         // Be careful how you consume this data - it has not been escaped and contains untrusted user-supplied content.
         // For example, if you plan to insert it into an HTML DOM, you must escape it on the client side (or use client-side templating).
-        return $sprunje->toResponse($response);
+		//set cache headers in order to stop specially IE to cache the result
+        return $sprunje->toResponse($response)->withHeader('Cache-Control', 'no-cache')->withHeader('Expires', '-1');
     }
 
     /**
@@ -420,7 +421,8 @@ class UserController extends SimpleController
 
         // Be careful how you consume this data - it has not been escaped and contains untrusted user-supplied content.
         // For example, if you plan to insert it into an HTML DOM, you must escape it on the client side (or use client-side templating).
-        return $sprunje->toResponse($response);
+		//set cache headers in order to stop specially IE to cache the result
+        return $sprunje->toResponse($response)->withHeader('Cache-Control', 'no-cache')->withHeader('Expires', '-1');
     }
 
     /**
@@ -768,8 +770,9 @@ class UserController extends SimpleController
 
         $params['user_id'] = $user->id;
         $sprunje = $classMapper->createInstance('user_permission_sprunje', $classMapper, $params);
-
-        $response = $sprunje->toResponse($response);
+		
+		//set cache headers in order to stop specially IE to cache the result
+        $response = $sprunje->toResponse($response)->withHeader('Cache-Control', 'no-cache')->withHeader('Expires', '-1');
 
         // Be careful how you consume this data - it has not been escaped and contains untrusted user-supplied content.
         // For example, if you plan to insert it into an HTML DOM, you must escape it on the client side (or use client-side templating).
@@ -818,7 +821,8 @@ class UserController extends SimpleController
 
         // Be careful how you consume this data - it has not been escaped and contains untrusted user-supplied content.
         // For example, if you plan to insert it into an HTML DOM, you must escape it on the client side (or use client-side templating).
-        return $sprunje->toResponse($response);
+		//set cache headers in order to stop specially IE to cache the result
+        return $sprunje->toResponse($response)->withHeader('Cache-Control', 'no-cache')->withHeader('Expires', '-1');
     }
 
     /**


### PR DESCRIPTION
I was using UserFrosting to implement a software solution for a client of mine and it turned out that they were Internet Explorer fans. This was when I realized that UF tables did not work well in IE 11 and possibly Edge.
After debugging for some time, I came to the conclusion that this was because of the cache headers. I believe it is generally a good idea to set cache headers to disabled for API requests that would update frequently. So I set the cache headers for all Sprunje (Json) functions to "no-cache".
This fixed the IE problem which was a significant compatibility issue for UserFrosting.