### PR TITLE
Add second check to verification send link

### DIFF
--- a/app/sprinkles/account/templates/pages/sign-in.html.twig
+++ b/app/sprinkles/account/templates/pages/sign-in.html.twig
@@ -48,7 +48,7 @@
         </form>
 
         <a href="{{site.uri.public}}/account/forgot-password">{{translate('PASSWORD.FORGET')}}</a><br>
-        {% if site.registration.require_email_verification %}
+        {% if site.registration.require_email_verification and site.registration.enabled %}
             <a href="{{site.uri.public}}/account/resend-verification">{{translate('ACCOUNT.VERIFICATION.RESEND')}}</a><br>
         {% endif %}
         {% if site.registration.enabled %}


### PR DESCRIPTION
Verification send link still appeared on sign-in page even though site.registration.enabled was false. Now checks for both email verification and registration enabled settings. https://chat.userfrosting.com/channel/support?msg=33dXQYphmY9jwTTiA