### PR TITLE
Enable User Create without Email for Developers

### DIFF
--- a/app/sprinkles/account/config/default.php
+++ b/app/sprinkles/account/config/default.php
@@ -51,7 +51,7 @@
                 'enable_email' => true
             ],
             'registration' => [
-                'enabled' => true,
+                'enabled' => true, //if this set to false, you probably want to also set require_email_verification to false as well to disable the link on the signup page
                 'captcha' => true,
                 'require_email_verification' => true,
                 'user_defaults' => [


### PR DESCRIPTION
Enable developers to use the Create User form even if they have not configured email.