### PR TITLE
Avoid twig deprecation warning

### DIFF
--- a/app/sprinkles/core/templates/modals/modal.html.twig
+++ b/app/sprinkles/core/templates/modals/modal.html.twig
@@ -1,9 +1,6 @@
 {# Base layout for modals.
 #}
 
-{# Conditional block.  See http://stackoverflow.com/a/13806784/2970321 #}
-{% set _modal_footer = block('modal_footer') %}
-
 <div class="modal fade" role="dialog">
     <div class="modal-dialog {% block modal_size %}{% endblock %}" role="document">
         <div class="modal-content">
@@ -17,9 +14,9 @@
                 {% block modal_body %}
                 {% endblock %}
             </div>
-            {% if _modal_footer is not empty %}
+            {% if block('modal_footer') is defined %}
                 <div class="modal-footer">
-                    {{ _modal_footer | raw }}
+                    {{ block('modal_footer') | raw }}
                 </div>
             {% endif %}
         </div>


### PR DESCRIPTION
Using "is defined" for prevent twig deprecation message:

`Silent display of undefined block "modal_footer" in template "modals/modal.html.twig" is deprecated since version 1.29 and will throw an exception in 2.0. Use the "block('modal_footer') is defined" expression to test for block existence`

https://github.com/twigphp/Twig/commit/ae9b503b17419102dbec3da4a583cf02c3ecf366