### PR TITLE
WIP: Fix Docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - .:/app
     links:
       - mysql
+
   nginx:
     build:
       context: ./docker/nginx
@@ -23,6 +24,7 @@ services:
       - .:/app
     links:
       - php
+
   mysql:
     image: mysql:5.7
     environment:
@@ -34,13 +36,6 @@ services:
       - 8571:3306
     volumes:
       - userfrosting-db:/var/lib/mysql
-
-  composer:
-    image: composer/composer
-    volumes_from:
-      - php
-    working_dir: /app
-    command: -V
 
   node:
     image: node:alpine

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,7 +7,6 @@ Second, initialize a new UserFrosting project:
 1. Copy `app/sprinkles/sprinkles.example.json` to `app/sprinkles/sprinkles.json`
 2. Run `chmod 777 app/{logs,cache,sessions}` to fix file permissions for web server. (NOTE: File
    permissions should be properly secured in a production environment!)
-2. Run `docker-compose run composer install` to install all composer modules.
 3. Run `docker-compose run node npm install` to install all npm modules.
 
 Now you can start up the entire Nginx + PHP + MySQL stack using docker with:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.0-fpm
 RUN apt-get update && apt-get install -y \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
-        libpng12-dev \
+        libpng-dev \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) gd \
     && docker-php-ext-install -j$(nproc) pdo pdo_mysql


### PR DESCRIPTION
See https://github.com/davidk132/processwire-docker-compose/commit/b5097e250472bd27c4d184b29c787939274f05ce for further details about the change.

Error before:

```
Package libpng12-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'libpng12-dev' has no installation candidate
ERROR: Service 'php' failed to build: The command '/bin/sh -c apt-get update && apt-get install -y         libfreetype6-dev         libjpeg62-turbo-dev         libpng12-dev     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/     && docker-php-ext-install -j$(nproc) gd     && docker-php-ext-install -j$(nproc) pdo pdo_mysql' returned a non-zero code: 100
```

After running:

`docker-compose up`