### PR TITLE
Extended bakery test to add Test Scope

### DIFF
--- a/app/sprinkles/account/factories/Users.php
+++ b/app/sprinkles/account/factories/Users.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * UserFrosting (http://www.userfrosting.com)
  *
@@ -11,12 +12,12 @@ use League\FactoryMuffin\Faker\Facade as Faker;
  * General factory for the User Model
  */
 $fm->define('UserFrosting\Sprinkle\Account\Database\Models\User')->setDefinitions([
-    'user_name'     => Faker::unique()->firstNameMale(),
-    'first_name'    => Faker::firstNameMale(),
-    'last_name'     => Faker::firstNameMale(),
-    'email'         => Faker::unique()->email(),
-    'locale'        => 'en_US',
+    'user_name' => Faker::unique()->userName(),
+    'first_name' => Faker::firstName(),
+    'last_name' => Faker::lastName(),
+    'email' => Faker::unique()->email(),
+    'locale' => 'en_US',
     'flag_verified' => 1,
-    'flag_enabled'  => 1,
-    'password'      => Faker::password()
+    'flag_enabled' => 1,
+    'password' => Faker::password()
 ]);

--- a/app/sprinkles/account/tests/Unit/HasherTest.php
+++ b/app/sprinkles/account/tests/Unit/HasherTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * UserFrosting (http://www.userfrosting.com)
  *
@@ -6,7 +7,7 @@
  * @license   https://github.com/userfrosting/UserFrosting/blob/master/licenses/UserFrosting.md (MIT License)
  */
 
-namespace UserFrosting\Tests\Unit;
+namespace UserFrosting\Sprinkle\Account\Tests\Unit;
 
 use UserFrosting\Sprinkle\Account\Authenticate\Hasher;
 use UserFrosting\Tests\TestCase;

--- a/app/sprinkles/account/tests/Unit/PDOStorageTest.php
+++ b/app/sprinkles/account/tests/Unit/PDOStorageTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * UserFrosting (http://www.userfrosting.com)
  *
@@ -6,7 +7,7 @@
  * @license   https://github.com/userfrosting/UserFrosting/blob/master/licenses/UserFrosting.md (MIT License)
  */
 
-namespace UserFrosting\Tests\Unit;
+namespace UserFrosting\Sprinkle\Account\Tests\Unit;
 
 use Birke\Rememberme\Storage\StorageInterface;
 use Carbon\Carbon;
@@ -99,10 +100,10 @@ class PDOStorageTest extends TestCase
     {
         $this->insertTestData();
         $persistence = new Persistence([
-            'user_id'          => $this->testUser->id,
-            'token'            => 'dummy',
+            'user_id' => $this->testUser->id,
+            'token' => 'dummy',
             'persistent_token' => 'dummy',
-            'expires_at'       => null
+            'expires_at' => null
         ]);
         $persistence->save();
         $this->storage->cleanAllTriplets($this->testUser->id);
@@ -122,10 +123,10 @@ class PDOStorageTest extends TestCase
     {
         $this->insertTestData();
         $persistence = new Persistence([
-            'user_id'          => $this->testUser->id,
-            'token'            => 'dummy',
+            'user_id' => $this->testUser->id,
+            'token' => 'dummy',
             'persistent_token' => 'dummy',
-            'expires_at'       => Carbon::now()->subHour(1)
+            'expires_at' => Carbon::now()->subHour(1)
         ]);
         $persistence->save();
         $this->assertEquals(2, Persistence::count());
@@ -140,10 +141,10 @@ class PDOStorageTest extends TestCase
     protected function insertTestData()
     {
         $persistence = new Persistence([
-            'user_id'          => $this->testUser->id,
-            'token'            => $this->validDBToken,
+            'user_id' => $this->testUser->id,
+            'token' => $this->validDBToken,
             'persistent_token' => $this->validDBPersistentToken,
-            'expires_at'       => $this->expire
+            'expires_at' => $this->expire
         ]);
         $persistence->save();
 

--- a/app/sprinkles/account/tests/Unit/RegistrationTest.php
+++ b/app/sprinkles/account/tests/Unit/RegistrationTest.php
@@ -78,14 +78,29 @@ class RegistrationTest extends TestCase
 
         // We try to register the same user again. Should throw an error
         $registration = new Registration($this->ci, $fakeUserData);
-        $this->expectException(HttpException::class);
-        $validation = $registration->validate();
+//        $this->expectException(HttpException::class);
+// Commenting expectExcaption as this causes a failure, even though the exception is raised.
+        $exception_thrown = false;
+        try {
+            $validation = $registration->validate();
+        } catch (HttpException $e) {
+            $exception_thrown = true;
+        }
+        $this->assertTrue($exception_thrown);
 
         // Should throw email error if we change the username
         $fakeUserData['user_name'] = 'BarFoo';
         $registration = new Registration($this->ci, $fakeUserData);
-        $this->expectException(HttpException::class);
-        $validation = $registration->validate();
+//        $this->expectException(HttpException::class);
+// Commenting expectExcaption as this causes a failure, even though the exception is raised.
+        $exception_thrown = false;
+        try {
+            $validation = $registration->validate();
+        } catch (HttpException $e) {
+//            $this->expectException(HttpException::class);
+            $exception_thrown = true;
+        }
+        $this->assertTrue($exception_thrown);
     }
 
     /**
@@ -126,7 +141,15 @@ class RegistrationTest extends TestCase
         ]);
 
         // Validate user. Shouldn't tell us the username is already in use since we reset the database
-        $this->expectException(HttpException::class);
-        $validation = $registration->validate();
+//        $this->expectException(HttpException::class);
+// Commenting expectExcaption as this causes a failure, even though the exception is raised.
+        $exception_thrown = false;
+        try {
+            $validation = $registration->validate();
+        } catch (HttpException $e) {
+//            $this->expectException(HttpException::class);
+            $exception_thrown = true;
+        }
+        $this->assertTrue($exception_thrown);
     }
 }

--- a/app/sprinkles/account/tests/Unit/RegistrationTest.php
+++ b/app/sprinkles/account/tests/Unit/RegistrationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * UserFrosting (http://www.userfrosting.com)
  *
@@ -6,7 +7,7 @@
  * @license   https://github.com/userfrosting/UserFrosting/blob/master/licenses/UserFrosting.md (MIT License)
  */
 
-namespace UserFrosting\Tests\Unit;
+namespace UserFrosting\Sprinkle\Account\Tests\Unit;
 
 use Mockery as m;
 use UserFrosting\Tests\TestCase;
@@ -57,11 +58,11 @@ class RegistrationTest extends TestCase
 
         // Genereate user data
         $fakeUserData = [
-            'user_name'     => 'FooBar',
-            'first_name'    => 'Foo',
-            'last_name'     => 'Bar',
-            'email'         => 'Foo@Bar.com',
-            'password'      => 'FooBarFooBar123'
+            'user_name' => 'FooBar',
+            'first_name' => 'Foo',
+            'last_name' => 'Bar',
+            'email' => 'Foo@Bar.com',
+            'password' => 'FooBarFooBar123'
         ];
 
         // Get class
@@ -96,11 +97,11 @@ class RegistrationTest extends TestCase
         $this->refreshDatabase();
 
         $registration = new Registration($this->ci, [
-            'user_name'     => 'FooBar',
-            'first_name'    => 'Foo',
-            'last_name'     => 'Bar',
-            'email'         => 'Foo@Bar.com',
-            'password'      => 'FooBarFooBar123'
+            'user_name' => 'FooBar',
+            'first_name' => 'Foo',
+            'last_name' => 'Bar',
+            'email' => 'Foo@Bar.com',
+            'password' => 'FooBarFooBar123'
         ]);
 
         // Validate user. Shouldn't tell us the username is already in use since we reset the database
@@ -117,11 +118,11 @@ class RegistrationTest extends TestCase
         $this->refreshDatabase();
 
         $registration = new Registration($this->ci, [
-            'user_name'     => 'FooBar',
+            'user_name' => 'FooBar',
             //'first_name'    => 'Foo',
-            'last_name'     => 'Bar',
-            'email'         => 'Foo@Bar.com',
-            'password'      => 'FooBarFooBar123'
+            'last_name' => 'Bar',
+            'email' => 'Foo@Bar.com',
+            'password' => 'FooBarFooBar123'
         ]);
 
         // Validate user. Shouldn't tell us the username is already in use since we reset the database

--- a/app/system/Bakery/Command/Test.php
+++ b/app/system/Bakery/Command/Test.php
@@ -35,9 +35,9 @@ class Test extends BaseCommand
     {
         $this->setName('test')
             ->addOption('coverage', 'c', InputOption::VALUE_NONE, 'Generate code coverage report in HTML format. Will be saved in _meta/coverage')
-            ->addArgument('sprinkle', InputArgument::OPTIONAL, 'Sprinkle Name (Optional): ')
-            ->setDescription('Run tests, Optionally Specify Sprinkle name')
-            ->setHelp('Run php unit tests, Optionally Specify Sprinkle name');
+            ->addArgument('testscope', InputArgument::OPTIONAL, 'Test Scope :Sprinkle, Class and Medhod  Name (Optional): ')
+            ->setDescription('Run tests, Optionally sprcific Sprinkle, Class and Medhod ')
+            ->setHelp('Run php unit tests, Optionally specif Sprinkle, Class and Medhod name');
     }
 
     /**
@@ -46,8 +46,6 @@ class Test extends BaseCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->io->title("UserFrosting's Tester");
-        $this->io->text("Optionally Specify Sprinkle name as an argument");
-        $this->io->newLine();
 
         // Get command
         $command = \UserFrosting\VENDOR_DIR . '/bin/phpunit --colors=always';
@@ -55,10 +53,17 @@ class Test extends BaseCommand
             $command .= ' -v';
         }
 
-        $sprinkle = $input->getArgument('sprinkle');
-        if ($sprinkle) {
+        $testscope = $input->getArgument('testscope');
+        if ($testscope) {
             $slashes = " \\\\ ";
-            $command .= " --filter='UserFrosting" . trim($slashes) . "Sprinkle" . trim($slashes) . $sprinkle . trim($slashes) . "Tests" . trim($slashes) . "' ";
+            if (strpos($testscope, "\\") !== false) {
+                $this->io->writeln("> <comment>Executing Specified Test Scope $testscope</comment>");
+                $testscope1 = str_replace("\\", trim($slashes), $testscope);
+                $command .= " --filter='UserFrosting" . trim($slashes) . "Sprinkle" . trim($slashes) . $testscope1 . "'";
+            } else {
+                $this->io->writeln("> <comment>Executing all tests in Sprinkle $testscope</comment>");
+                $command .= " --filter='UserFrosting" . trim($slashes) . "Sprinkle" . trim($slashes) . $testscope . trim($slashes) . "Tests" . trim($slashes) . "' ";
+            }
         }
 
         // Add coverage report

--- a/app/system/Bakery/Command/Test.php
+++ b/app/system/Bakery/Command/Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * UserFrosting (http://www.userfrosting.com)
  *
@@ -11,6 +12,7 @@ namespace UserFrosting\System\Bakery\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
 use UserFrosting\System\Bakery\BaseCommand;
 
 /**
@@ -32,9 +34,10 @@ class Test extends BaseCommand
     protected function configure()
     {
         $this->setName('test')
-             ->addOption('coverage', 'c', InputOption::VALUE_NONE, 'Generate code coverage report in HTML format. Will be saved in _meta/coverage')
-             ->setDescription('Run tests')
-             ->setHelp('Run php unit tests');
+            ->addOption('coverage', 'c', InputOption::VALUE_NONE, 'Generate code coverage report in HTML format. Will be saved in _meta/coverage')
+            ->addArgument('sprinkle', InputArgument::OPTIONAL, 'Sprinkle Name (Optional): ')
+            ->setDescription('Run tests, Optionally Specify Sprinkle name')
+            ->setHelp('Run php unit tests, Optionally Specify Sprinkle name');
     }
 
     /**
@@ -43,11 +46,19 @@ class Test extends BaseCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->io->title("UserFrosting's Tester");
+        $this->io->text("Optionally Specify Sprinkle name as an argument");
+        $this->io->newLine();
 
         // Get command
         $command = \UserFrosting\VENDOR_DIR . '/bin/phpunit --colors=always';
         if ($output->isVerbose() || $output->isVeryVerbose()) {
             $command .= ' -v';
+        }
+
+        $sprinkle = $input->getArgument('sprinkle');
+        if ($sprinkle) {
+            $slashes = " \\\\ ";
+            $command .= " --filter='UserFrosting" . trim($slashes) . "Sprinkle" . trim($slashes) . $sprinkle . trim($slashes) . "Tests" . trim($slashes) . "' ";
         }
 
         // Add coverage report

--- a/docker-compose-testdb.yml
+++ b/docker-compose-testdb.yml
@@ -1,0 +1,95 @@
+version: "3.2"
+services:
+  php:
+    image: regsevak.com/php
+    restart: unless-stopped
+    tty: true
+    build:
+      context: ./docker/php
+    environment:
+      - DB_DRIVER=mysql
+      - DB_HOST=mysqlprod
+      - DB_PORT=3306
+      - DB_NAME=uf42chinmaya_dbdocker
+      - DB_USER=docker
+      - DB_PASSWORD=secret
+      - DB_TEST_DRIVER=mysql
+      - DB_TEST_HOST=mysqltest
+      - DB_TEST_PORT=3306
+      - DB_TEST_NAME=uf42chinmaya_test_dbdocker
+      - DB_TEST_USER=docker
+      - DB_TEST_PASSWORD=secret
+      - TEST_DB=test_chinmaya
+    volumes:
+      - .:/app
+    networks:
+      - backend
+  nginx:
+    restart: unless-stopped
+    tty: true
+    ports:
+      - "8580:80"
+      - "8581:443"
+    build:
+      context: ./docker/nginx
+    volumes:
+      - .:/app
+    depends_on:
+      - php
+      - mysqlprod
+      - mysqltest
+    networks:
+      - frontend
+      - backend
+  mysqlprod:
+    image: mysql:5.7
+    networks:
+      - backend
+    environment:
+      - MYSQL_DATABASE=uf42chinmaya_dbdocker
+      - MYSQL_ROOT_PASSWORD=secret
+      - MYSQL_USER=docker
+      - MYSQL_PASSWORD=secret
+    ports:
+      - 8571:3306
+    volumes:
+      - uf42chinmaya-db:/var/lib/mysql
+  mysqltest:
+    image: mysql:5.7
+    networks:
+      - backend
+    environment:
+      - MYSQL_DATABASE=uf42chinmaya_test_dbdocker
+      - MYSQL_ROOT_PASSWORD=secret
+      - MYSQL_USER=docker
+      - MYSQL_PASSWORD=secret
+    ports:
+      - 8572:3306
+    volumes:
+      - uf42chinmaya-testdb:/var/lib/mysql
+
+  composer:
+    image: composer/composer
+    volumes:
+      - .:/app
+    working_dir: /app
+    command: -V
+
+  node:
+    image: node:alpine
+    build:
+      context: ./docker/node
+    volumes:
+      - .:/app
+    working_dir: /app/build
+    command: npm run uf-assets-install
+
+volumes:
+  uf42chinmaya-db:
+    driver: local
+  uf42chinmaya-testdb:
+    driver: local
+
+networks:
+  frontend:
+  backend:

--- a/docker-compose2.yml
+++ b/docker-compose2.yml
@@ -1,68 +1,56 @@
-version: "3.2"
+version: '2'
 services:
   php:
-    image: userforsting.local/php
-    restart: unless-stopped
-    tty: true
     build:
       context: ./docker/php
     environment:
       - DB_DRIVER=mysql
-      - DB_HOST=mysqlprod
+      - DB_HOST=mysql
       - DB_PORT=3306
       - DB_NAME=userfrosting
-      - DB_USER=docker
-      - DB_PASSWORD=secret
+      - DB_USER=userfrosting
+      - DB_PASSWORD=password
     volumes:
       - .:/app
-    networks:
-      - backend
+    links:
+      - mysql
   nginx:
-    restart: unless-stopped
-    tty: true
-    ports:
-      - "8570:80"
-      - "8581:443"
     build:
       context: ./docker/nginx
+    ports:
+      - 8570:80
     volumes:
       - .:/app
-    depends_on:
+    links:
       - php
-      - mysql
-    networks:
-      - frontend
-      - backend
   mysql:
     image: mysql:5.7
-    networks:
-      - backend
     environment:
       - MYSQL_DATABASE=userfrosting
-      - MYSQL_ROOT_PASSWORD=secret
-      - MYSQL_USER=docker
-      - MYSQL_PASSWORD=secret
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_USER=userfrosting
+      - MYSQL_PASSWORD=password
     ports:
       - 8571:3306
     volumes:
       - userfrosting-db:/var/lib/mysql
+
   composer:
     image: composer/composer
-    volumes:
-      - .:/app
+    volumes_from:
+      - php
     working_dir: /app
     command: -V
+
   node:
     image: node:alpine
     build:
       context: ./docker/node
-    volumes:
-      - .:/app
+    volumes_from:
+      - php
     working_dir: /app/build
     command: npm run uf-assets-install
+
 volumes:
   userfrosting-db:
-    driver: local
-networks:
-  frontend:
-  backend:
+


### PR DESCRIPTION
extended this to have the second argument to be either just the sprinkle name or a full qualified path to the test case and method.
usage `php bakery test CRUD`, 
`php bakery test 'CRUD\Tests\Unit\'`,
`php bakery test 'CRUD\Tests\Unit\CRUDTest'`,
`php bakery test 'CRUD\Tests\Unit\CRUDTest::testCRUDMethod'`