### PR TITLE
Fix 404 for delete group from detail page

### DIFF
--- a/app/sprinkles/admin/src/Controller/GroupController.php
+++ b/app/sprinkles/admin/src/Controller/GroupController.php
@@ -228,7 +228,8 @@ class GroupController extends SimpleController
 
         // If the group doesn't exist, return 404
         if (!$group) {
-            throw new NotFoundException($request, $response);
+            $redirectPage = $this->ci->router->pathFor('uri_groups');
+            return $response->withRedirect($redirectPage, 301);
         }
 
         // Get group


### PR DESCRIPTION
when deleting a group on route getInfo the group gets deleted. after success (200) app tries to reload the getInfo page where group doesn't exists anymore. therefore a redirect to main page is better than 404.