### PR TITLE
Better deletion redirects for user, group, and role pages plus related improvements

### DIFF
--- a/app/sprinkles/account/assets/userfrosting/js/pages/register.js
+++ b/app/sprinkles/account/assets/userfrosting/js/pages/register.js
@@ -8,7 +8,9 @@
  */
 $(document).ready(function() {
     // TOS modal
-    $(this).find('.js-show-tos').click(function() {
+    $(this).find('.js-show-tos').click(function(e) {
+        e.preventDefault();
+
         $("body").ufModal({
             sourceUrl: site.uri.public + "/modals/account/tos",
             msgTarget: $("#alerts-page")

--- a/app/sprinkles/account/src/Controller/AccountController.php
+++ b/app/sprinkles/account/src/Controller/AccountController.php
@@ -13,7 +13,6 @@ use Carbon\Carbon;
 use Illuminate\Database\Capsule\Manager as Capsule;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Exception\NotFoundException as NotFoundException;
 use UserFrosting\Fortress\RequestDataTransformer;
 use UserFrosting\Fortress\RequestSchema;
 use UserFrosting\Fortress\ServerSideValidator;
@@ -28,6 +27,7 @@ use UserFrosting\Sprinkle\Core\Mail\TwigMailMessage;
 use UserFrosting\Sprinkle\Core\Util\Captcha;
 use UserFrosting\Support\Exception\BadRequestException;
 use UserFrosting\Support\Exception\ForbiddenException;
+use UserFrosting\Support\Exception\NotFoundException;
 
 /**
  * Controller class for /account/* URLs.  Handles account-related activities, including login, registration, password recovery, and account settings.
@@ -489,7 +489,7 @@ class AccountController extends SimpleController
         $localePathBuilder = $this->ci->localePathBuilder;
 
         if (!$config['site.registration.enabled']) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Account\Authenticate\Authenticator $authenticator */

--- a/app/sprinkles/admin/assets/userfrosting/js/pages/dashboard.js
+++ b/app/sprinkles/admin/assets/userfrosting/js/pages/dashboard.js
@@ -6,7 +6,9 @@
  */
 
 $(document).ready(function() {
-    $('.js-clear-cache').click(function() {
+    $('.js-clear-cache').click(function(e) {
+        e.preventDefault();
+
         $("body").ufModal({
             sourceUrl: site.uri.public + "/modals/dashboard/clear-cache",
             ajaxParams: {

--- a/app/sprinkles/admin/assets/userfrosting/js/pages/group.js
+++ b/app/sprinkles/admin/assets/userfrosting/js/pages/group.js
@@ -9,7 +9,7 @@
 
 $(document).ready(function() {
     // Control buttons
-    bindGroupButtons($("#view-group"));
+    bindGroupButtons($("#view-group"), { delete_redirect: page.delete_redirect });
 
     // Table of users in this group
     $("#widget-group-users").ufTable({

--- a/app/sprinkles/admin/assets/userfrosting/js/pages/role.js
+++ b/app/sprinkles/admin/assets/userfrosting/js/pages/role.js
@@ -9,7 +9,7 @@
 
 $(document).ready(function() {
     // Control buttons
-    bindRoleButtons($("#view-role"));
+    bindRoleButtons($("#view-role"), { delete_redirect: page.delete_redirect });
 
     $("#widget-role-permissions").ufTable({
         dataUrl: site.uri.public + '/api/roles/r/' + page.role_slug + '/permissions',

--- a/app/sprinkles/admin/assets/userfrosting/js/pages/user.js
+++ b/app/sprinkles/admin/assets/userfrosting/js/pages/user.js
@@ -9,7 +9,7 @@
 
 $(document).ready(function() {
     // Control buttons
-    bindUserButtons($("#view-user"));
+    bindUserButtons($("#view-user"), { delete_redirect: page.delete_redirect });
 
     // Table of activities
     $("#widget-user-activities").ufTable({

--- a/app/sprinkles/admin/assets/userfrosting/js/widgets/groups.js
+++ b/app/sprinkles/admin/assets/userfrosting/js/widgets/groups.js
@@ -63,7 +63,9 @@ function bindGroupButtons(el) {
      * Buttons that launch a modal dialog
      */
     // Edit group details button
-    el.find('.js-group-edit').click(function() {
+    el.find('.js-group-edit').click(function(e) {
+        e.preventDefault();
+
         $("body").ufModal({
             sourceUrl: site.uri.public + "/modals/groups/edit",
             ajaxParams: {
@@ -76,7 +78,9 @@ function bindGroupButtons(el) {
     });
 
     // Delete group button
-    el.find('.js-group-delete').click(function() {
+    el.find('.js-group-delete').click(function(e) {
+        e.preventDefault();
+
         $("body").ufModal({
             sourceUrl: site.uri.public + "/modals/groups/confirm-delete",
             ajaxParams: {
@@ -85,7 +89,7 @@ function bindGroupButtons(el) {
             msgTarget: $("#alerts-page")
         });
 
-        $("body").on('renderSuccess.ufModal', function (data) {
+        $("body").on('renderSuccess.ufModal', function () {
             var modal = $(this).ufModal('getModal');
             var form = modal.find('.js-form');
 
@@ -100,7 +104,9 @@ function bindGroupButtons(el) {
 
 function bindGroupCreationButton(el) {
     // Link create button
-    el.find('.js-group-create').click(function() {
+    el.find('.js-group-create').click(function(e) {
+        e.preventDefault();
+
         $("body").ufModal({
             sourceUrl: site.uri.public + "/modals/groups/create",
             msgTarget: $("#alerts-page")

--- a/app/sprinkles/admin/assets/userfrosting/js/widgets/groups.js
+++ b/app/sprinkles/admin/assets/userfrosting/js/widgets/groups.js
@@ -53,8 +53,12 @@ function attachGroupForm() {
 
 /**
  * Link group action buttons, for example in a table or on a specific group's page.
+ * @param {module:jQuery} el jQuery wrapped element to target.
+ * @param {{delete_redirect: string}} options Options used to modify behaviour of button actions.
  */
-function bindGroupButtons(el) {
+function bindGroupButtons(el, options) {
+    if (!options) options = {};
+
     /**
      * Link row buttons after table is loaded.
      */
@@ -95,8 +99,9 @@ function bindGroupButtons(el) {
 
             form.ufForm()
             .on("submitSuccess.ufForm", function() {
-                // Reload page on success
-                window.location.reload();
+                // Navigate or reload page on success
+                if (options.delete_redirect) window.location.href = options.delete_redirect;
+                else window.location.reload();
             });
         });
     });

--- a/app/sprinkles/admin/assets/userfrosting/js/widgets/roles.js
+++ b/app/sprinkles/admin/assets/userfrosting/js/widgets/roles.js
@@ -44,8 +44,12 @@ function attachRoleForm() {
 
 /**
  * Link role action buttons, for example in a table or on a specific role's page.
+ * @param {module:jQuery} el jQuery wrapped element to target.
+ * @param {{delete_redirect: string}} options Options used to modify behaviour of button actions.
  */
-function bindRoleButtons(el) {
+function bindRoleButtons(el, options) {
+    if (!options) options = {};
+
     /**
      * Link row buttons after table is loaded.
      */
@@ -134,8 +138,9 @@ function bindRoleButtons(el) {
 
             form.ufForm()
             .on("submitSuccess.ufForm", function() {
-                // Reload page on success
-                window.location.reload();
+                // Navigate or reload page on success
+                if (options.delete_redirect) window.location.href = options.delete_redirect;
+                else window.location.reload();
             });
         });
     });

--- a/app/sprinkles/admin/assets/userfrosting/js/widgets/roles.js
+++ b/app/sprinkles/admin/assets/userfrosting/js/widgets/roles.js
@@ -51,7 +51,9 @@ function bindRoleButtons(el) {
      */
 
     // Manage permissions button
-    el.find('.js-role-permissions').click(function() {
+    el.find('.js-role-permissions').click(function(e) {
+        e.preventDefault();
+
         var slug = $(this).data('slug');
         $("body").ufModal({
             sourceUrl: site.uri.public + "/modals/roles/permissions",
@@ -100,7 +102,9 @@ function bindRoleButtons(el) {
      * Buttons that launch a modal dialog
      */
     // Edit role details button
-    el.find('.js-role-edit').click(function() {
+    el.find('.js-role-edit').click(function(e) {
+        e.preventDefault();
+
         $("body").ufModal({
             sourceUrl: site.uri.public + "/modals/roles/edit",
             ajaxParams: {
@@ -113,7 +117,9 @@ function bindRoleButtons(el) {
     });
 
     // Delete role button
-    el.find('.js-role-delete').click(function() {
+    el.find('.js-role-delete').click(function(e) {
+        e.preventDefault();
+
         $("body").ufModal({
             sourceUrl: site.uri.public + "/modals/roles/confirm-delete",
             ajaxParams: {
@@ -137,7 +143,9 @@ function bindRoleButtons(el) {
 
 function bindRoleCreationButton(el) {
     // Link create button
-    el.find('.js-role-create').click(function() {
+    el.find('.js-role-create').click(function(e) {
+        e.preventDefault();
+
         $("body").ufModal({
             sourceUrl: site.uri.public + "/modals/roles/create",
             msgTarget: $("#alerts-page")

--- a/app/sprinkles/admin/assets/userfrosting/js/widgets/users.js
+++ b/app/sprinkles/admin/assets/userfrosting/js/widgets/users.js
@@ -125,8 +125,11 @@ function updateUser(userName, fieldName, fieldValue) {
 
 /**
  * Link user action buttons, for example in a table or on a specific user's page.
+ * @param {module:jQuery} el jQuery wrapped element to target.
+ * @param {{delete_redirect: string}} options Options used to modify behaviour of button actions.
  */
- function bindUserButtons(el) {
+ function bindUserButtons(el, options) {
+     if (!options) options = {};
 
     /**
      * Buttons that launch a modal dialog
@@ -243,14 +246,15 @@ function updateUser(userName, fieldName, fieldValue) {
             msgTarget: $("#alerts-page")
         });
 
-        $("body").on('renderSuccess.ufModal', function (data) {
+        $("body").on('renderSuccess.ufModal', function () {
             var modal = $(this).ufModal('getModal');
             var form = modal.find('.js-form');
 
             form.ufForm()
             .on("submitSuccess.ufForm", function() {
-                // Reload page on success
-                window.location.reload();
+                // Navigate or reload page on success
+                if (options.delete_redirect) window.location.href = options.delete_redirect;
+                else window.location.reload();
             });
         });
     });

--- a/app/sprinkles/admin/assets/userfrosting/js/widgets/users.js
+++ b/app/sprinkles/admin/assets/userfrosting/js/widgets/users.js
@@ -132,7 +132,9 @@ function updateUser(userName, fieldName, fieldValue) {
      * Buttons that launch a modal dialog
      */
     // Edit general user details button
-    el.find('.js-user-edit').click(function() {
+    el.find('.js-user-edit').click(function(e) {
+        e.preventDefault();
+
         $("body").ufModal({
             sourceUrl: site.uri.public + "/modals/users/edit",
             ajaxParams: {
@@ -145,7 +147,9 @@ function updateUser(userName, fieldName, fieldValue) {
     });
 
     // Manage user roles button
-    el.find('.js-user-roles').click(function() {
+    el.find('.js-user-roles').click(function(e) {
+        e.preventDefault();
+
         var userName = $(this).data('user_name');
         $("body").ufModal({
             sourceUrl: site.uri.public + "/modals/users/roles",
@@ -191,7 +195,9 @@ function updateUser(userName, fieldName, fieldValue) {
     });
 
     // Change user password button
-    el.find('.js-user-password').click(function() {
+    el.find('.js-user-password').click(function(e) {
+        e.preventDefault();
+
         var userName = $(this).data('user_name');
         $("body").ufModal({
             sourceUrl: site.uri.public + "/modals/users/password",
@@ -201,7 +207,7 @@ function updateUser(userName, fieldName, fieldValue) {
             msgTarget: $("#alerts-page")
         });
 
-        $("body").on('renderSuccess.ufModal', function (data) {
+        $("body").on('renderSuccess.ufModal', function () {
             var modal = $(this).ufModal('getModal');
             var form = modal.find('.js-form');
 
@@ -216,7 +222,9 @@ function updateUser(userName, fieldName, fieldValue) {
             toggleChangePasswordMode(modal, userName, 'link');
 
             // On submission, submit either the PUT request, or POST for a password reset, depending on the toggle state
-            modal.find("input[name='change_password_mode']").click(function() {
+            modal.find("input[name='change_password_mode']").click(function(e) {
+                e.preventDefault();
+
                 var changePasswordMode = $(this).val();
                 toggleChangePasswordMode(modal, userName, changePasswordMode);
             });
@@ -224,7 +232,9 @@ function updateUser(userName, fieldName, fieldValue) {
     });
 
     // Delete user button
-    el.find('.js-user-delete').click(function() {
+    el.find('.js-user-delete').click(function(e) {
+        e.preventDefault();
+
         $("body").ufModal({
             sourceUrl: site.uri.public + "/modals/users/confirm-delete",
             ajaxParams: {
@@ -248,7 +258,9 @@ function updateUser(userName, fieldName, fieldValue) {
     /**
      * Direct action buttons
      */
-    el.find('.js-user-activate').click(function() {
+    el.find('.js-user-activate').click(function(e) {
+        e.preventDefault();
+
         var btn = $(this);
         updateUser(btn.data('user_name'), 'flag_verified', '1');
     });
@@ -266,7 +278,9 @@ function updateUser(userName, fieldName, fieldValue) {
 
 function bindUserCreationButton(el) {
     // Link create button
-    el.find('.js-user-create').click(function() {
+    el.find('.js-user-create').click(function(e) {
+        e.preventDefault();
+
         $("body").ufModal({
             sourceUrl: site.uri.public + "/modals/users/create",
             msgTarget: $("#alerts-page")

--- a/app/sprinkles/admin/src/Controller/GroupController.php
+++ b/app/sprinkles/admin/src/Controller/GroupController.php
@@ -12,7 +12,6 @@ namespace UserFrosting\Sprinkle\Admin\Controller;
 use Illuminate\Database\Capsule\Manager as Capsule;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Exception\NotFoundException;
 use UserFrosting\Fortress\RequestDataTransformer;
 use UserFrosting\Fortress\RequestSchema;
 use UserFrosting\Fortress\ServerSideValidator;
@@ -21,6 +20,7 @@ use UserFrosting\Sprinkle\Account\Database\Models\Group;
 use UserFrosting\Sprinkle\Core\Controller\SimpleController;
 use UserFrosting\Support\Exception\BadRequestException;
 use UserFrosting\Support\Exception\ForbiddenException;
+use UserFrosting\Support\Exception\NotFoundException;
 
 /**
  * Controller class for group-related requests, including listing groups, CRUD for groups, etc.
@@ -147,7 +147,7 @@ class GroupController extends SimpleController
 
         // If the group doesn't exist, return 404
         if (!$group) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Account\Authorize\AuthorizationManager $authorizer */
@@ -243,7 +243,7 @@ class GroupController extends SimpleController
 
         // If the group doesn't exist, return 404
         if (!$group) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         // Get group
@@ -311,7 +311,7 @@ class GroupController extends SimpleController
 
         // If the group no longer exists, forward to main group listing page
         if (!$group) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Account\Authorize\AuthorizationManager $authorizer */
@@ -431,7 +431,7 @@ class GroupController extends SimpleController
 
         // If the group doesn't exist, return 404
         if (!$group) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Core\Util\ClassMapper $classMapper */
@@ -494,7 +494,7 @@ class GroupController extends SimpleController
 
         // If the group no longer exists, forward to main group listing page
         if (!$group) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         // GET parameters
@@ -659,7 +659,7 @@ class GroupController extends SimpleController
         $group = $this->getGroupFromParams($args);
 
         if (!$group) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Support\Repository\Repository $config */

--- a/app/sprinkles/admin/src/Controller/GroupController.php
+++ b/app/sprinkles/admin/src/Controller/GroupController.php
@@ -547,9 +547,7 @@ class GroupController extends SimpleController
 
         // If the group no longer exists, forward to main group listing page
         if (!$group) {
-            $redirectPage = $this->ci->router->pathFor('uri_groups');
-
-            return $response->withRedirect($redirectPage);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Account\Authorize\AuthorizationManager $authorizer */

--- a/app/sprinkles/admin/src/Controller/GroupController.php
+++ b/app/sprinkles/admin/src/Controller/GroupController.php
@@ -601,7 +601,8 @@ class GroupController extends SimpleController
         return $this->ci->view->render($response, 'pages/group.html.twig', [
             'group'  => $group,
             'fields' => $fields,
-            'tools'  => $editButtons
+            'tools'  => $editButtons,
+            'delete_redirect' => $this->ci->router->pathFor('uri_groups')
         ]);
     }
 

--- a/app/sprinkles/admin/src/Controller/PermissionController.php
+++ b/app/sprinkles/admin/src/Controller/PermissionController.php
@@ -11,9 +11,9 @@ namespace UserFrosting\Sprinkle\Admin\Controller;
 
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Exception\NotFoundException;
 use UserFrosting\Sprinkle\Core\Controller\SimpleController;
 use UserFrosting\Support\Exception\ForbiddenException;
+use UserFrosting\Support\Exception\NotFoundException;
 
 /**
  * Controller class for permission-related requests, including listing permissions, CRUD for permissions, etc.
@@ -56,7 +56,7 @@ class PermissionController extends SimpleController
 
         // If the permission doesn't exist, return 404
         if (!$permission) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         // Get permission
@@ -182,7 +182,7 @@ class PermissionController extends SimpleController
 
         // If the permission doesn't exist, return 404
         if (!$permission) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         return $this->ci->view->render($response, 'pages/permission.html.twig', [

--- a/app/sprinkles/admin/src/Controller/RoleController.php
+++ b/app/sprinkles/admin/src/Controller/RoleController.php
@@ -12,7 +12,6 @@ namespace UserFrosting\Sprinkle\Admin\Controller;
 use Illuminate\Database\Capsule\Manager as Capsule;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Exception\NotFoundException;
 use UserFrosting\Fortress\RequestDataTransformer;
 use UserFrosting\Fortress\RequestSchema;
 use UserFrosting\Fortress\ServerSideValidator;
@@ -21,6 +20,7 @@ use UserFrosting\Sprinkle\Account\Database\Models\Role;
 use UserFrosting\Sprinkle\Core\Controller\SimpleController;
 use UserFrosting\Support\Exception\BadRequestException;
 use UserFrosting\Support\Exception\ForbiddenException;
+use UserFrosting\Support\Exception\NotFoundException;
 
 /**
  * Controller class for role-related requests, including listing roles, CRUD for roles, etc.
@@ -147,7 +147,7 @@ class RoleController extends SimpleController
 
         // If the role doesn't exist, return 404
         if (!$role) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Account\Authorize\AuthorizationManager $authorizer */
@@ -242,7 +242,7 @@ class RoleController extends SimpleController
 
         // If the role doesn't exist, return 404
         if (!$role) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         // Get role
@@ -310,7 +310,7 @@ class RoleController extends SimpleController
 
         // If the role no longer exists, forward to main role listing page
         if (!$role) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Account\Authorize\AuthorizationManager $authorizer */
@@ -438,7 +438,7 @@ class RoleController extends SimpleController
 
         // If the role doesn't exist, return 404
         if (!$role) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Core\Util\ClassMapper $classMapper */
@@ -508,7 +508,7 @@ class RoleController extends SimpleController
 
         // If the role doesn't exist, return 404
         if (!$role) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Account\Authorize\AuthorizationManager $authorizer */
@@ -549,7 +549,7 @@ class RoleController extends SimpleController
 
         // If the role no longer exists, forward to main role listing page
         if (!$role) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         // GET parameters
@@ -600,7 +600,7 @@ class RoleController extends SimpleController
 
         // If the role doesn't exist, return 404
         if (!$role) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Core\Util\ClassMapper $classMapper */
@@ -765,7 +765,7 @@ class RoleController extends SimpleController
         $role = $this->getRoleFromParams($args);
 
         if (!$role) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Support\Repository\Repository $config */
@@ -886,7 +886,7 @@ class RoleController extends SimpleController
         $role = $this->getRoleFromParams($args);
 
         if (!$role) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         // Get key->value pair from URL and request body

--- a/app/sprinkles/admin/src/Controller/RoleController.php
+++ b/app/sprinkles/admin/src/Controller/RoleController.php
@@ -653,9 +653,7 @@ class RoleController extends SimpleController
 
         // If the role no longer exists, forward to main role listing page
         if (!$role) {
-            $redirectPage = $this->ci->router->pathFor('uri_roles');
-
-            return $response->withRedirect($redirectPage);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Account\Authorize\AuthorizationManager $authorizer */

--- a/app/sprinkles/admin/src/Controller/RoleController.php
+++ b/app/sprinkles/admin/src/Controller/RoleController.php
@@ -707,7 +707,8 @@ class RoleController extends SimpleController
         return $this->ci->view->render($response, 'pages/role.html.twig', [
             'role'   => $role,
             'fields' => $fields,
-            'tools'  => $editButtons
+            'tools'  => $editButtons,
+            'delete_redirect' => $this->ci->router->pathFor('uri_roles')
         ]);
     }
 

--- a/app/sprinkles/admin/src/Controller/UserController.php
+++ b/app/sprinkles/admin/src/Controller/UserController.php
@@ -1020,7 +1020,8 @@ class UserController extends SimpleController
             'locales' => $locales,
             'fields'  => $fields,
             'tools'   => $editButtons,
-            'widgets' => $widgets
+            'widgets' => $widgets,
+            'delete_redirect' => $this->ci->router->pathFor('uri_users')
         ]);
     }
 

--- a/app/sprinkles/admin/src/Controller/UserController.php
+++ b/app/sprinkles/admin/src/Controller/UserController.php
@@ -13,7 +13,6 @@ use Carbon\Carbon;
 use Illuminate\Database\Capsule\Manager as Capsule;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Exception\NotFoundException;
 use UserFrosting\Fortress\RequestDataTransformer;
 use UserFrosting\Fortress\RequestSchema;
 use UserFrosting\Fortress\ServerSideValidator;
@@ -25,6 +24,7 @@ use UserFrosting\Sprinkle\Core\Mail\EmailRecipient;
 use UserFrosting\Sprinkle\Core\Mail\TwigMailMessage;
 use UserFrosting\Support\Exception\BadRequestException;
 use UserFrosting\Support\Exception\ForbiddenException;
+use UserFrosting\Support\Exception\NotFoundException;
 
 /**
  * Controller class for user-related requests, including listing users, CRUD for users, etc.
@@ -192,7 +192,7 @@ class UserController extends SimpleController
         $user = $this->getUserFromParams($args);
 
         if (!$user) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Account\Authorize\AuthorizationManager $authorizer */
@@ -265,7 +265,7 @@ class UserController extends SimpleController
 
         // If the user doesn't exist, return 404
         if (!$user) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Account\Authorize\AuthorizationManager $authorizer */
@@ -333,7 +333,7 @@ class UserController extends SimpleController
 
         // If the user doesn't exist, return 404
         if (!$user) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Core\Util\ClassMapper $classMapper */
@@ -384,7 +384,7 @@ class UserController extends SimpleController
 
         // If the user doesn't exist, return 404
         if (!$user) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Core\Util\ClassMapper $classMapper */
@@ -476,7 +476,7 @@ class UserController extends SimpleController
 
         // If the user doesn't exist, return 404
         if (!$user) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Account\Authorize\AuthorizationManager $authorizer */
@@ -624,7 +624,7 @@ class UserController extends SimpleController
 
         // If the user doesn't exist, return 404
         if (!$user) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Core\Util\ClassMapper $classMapper */
@@ -717,7 +717,7 @@ class UserController extends SimpleController
 
         // If the user doesn't exist, return 404
         if (!$user) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Account\Authorize\AuthorizationManager $authorizer */
@@ -768,7 +768,7 @@ class UserController extends SimpleController
 
         // If the user doesn't exist, return 404
         if (!$user) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Account\Authorize\AuthorizationManager $authorizer */
@@ -808,7 +808,7 @@ class UserController extends SimpleController
 
         // If the user doesn't exist, return 404
         if (!$user) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         // GET parameters
@@ -856,7 +856,7 @@ class UserController extends SimpleController
 
         // If the user doesn't exist, return 404
         if (!$user) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Core\Util\ClassMapper $classMapper */
@@ -1077,7 +1077,7 @@ class UserController extends SimpleController
         $user = $this->getUserFromParams($args);
 
         if (!$user) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Support\Repository\Repository $config */
@@ -1205,7 +1205,7 @@ class UserController extends SimpleController
         $user = $this->getUserFromParams($args);
 
         if (!$user) {
-            throw new NotFoundException($request, $response);
+            throw new NotFoundException();
         }
 
         // Get key->value pair from URL and request body

--- a/app/sprinkles/admin/src/Controller/UserController.php
+++ b/app/sprinkles/admin/src/Controller/UserController.php
@@ -909,9 +909,7 @@ class UserController extends SimpleController
 
         // If the user no longer exists, forward to main user listing page
         if (!$user) {
-            $usersPage = $this->ci->router->pathFor('uri_users');
-
-            return $response->withRedirect($usersPage);
+            throw new NotFoundException();
         }
 
         /** @var \UserFrosting\Sprinkle\Account\Authorize\AuthorizationManager $authorizer */

--- a/app/sprinkles/admin/templates/pages/group.html.twig
+++ b/app/sprinkles/admin/templates/pages/group.html.twig
@@ -88,11 +88,12 @@
     <script>
     {% include "pages/partials/page.js.twig" %}
 
-    // Add user name
+    // Add group slug
     page = $.extend(
-        true,               // deep extend
+        true, // deep extend
         {
-            "group_slug": "{{group.slug}}"
+            group_slug: "{{group.slug}}",
+            delete_redirect: "{{delete_redirect}}"
         },
         page
     );

--- a/app/sprinkles/admin/templates/pages/role.html.twig
+++ b/app/sprinkles/admin/templates/pages/role.html.twig
@@ -111,11 +111,12 @@
     <script>
     {% include "pages/partials/page.js.twig" %}
 
-    // Add user name
+    // Add role slug
     page = $.extend(
-        true,               // deep extend
+        true, // deep extend
         {
-            "role_slug": "{{role.slug}}"
+            role_slug: "{{role.slug}}",
+            delete_redirect: "{{delete_redirect}}"
         },
         page
     );

--- a/app/sprinkles/admin/templates/pages/user.html.twig
+++ b/app/sprinkles/admin/templates/pages/user.html.twig
@@ -179,9 +179,10 @@
 
     // Add user name
     page = $.extend(
-        true,               // deep extend
+        true, // deep extend
         {
-            "user_name": "{{user.user_name}}"
+            user_name: "{{user.user_name}}",
+            delete_redirect: "{{delete_redirect}}"
         },
         page
     );


### PR DESCRIPTION
- UserFrosting's `NotFoundException` is now used everywhere in place of Slim's, as it should do.
- Corrected group, role, and user pages to return 404 instead of redirecting.
- Implemented fix to prevent clearing of ufTable URL slug for numerous buttons.
- Moved redirection to client-side for deletion of pages that will result in a 404 on reload.

Addresses #932 