### PR TITLE
Update Sprunje.php

### DIFF
--- a/app/sprinkles/core/src/Sprunje/Sprunje.php
+++ b/app/sprinkles/core/src/Sprunje/Sprunje.php
@@ -188,8 +188,6 @@ abstract class Sprunje
             $result = $this->getCsv();
 
             // Prepare response
-            $settings = http_build_query($this->options);
-            $date = Carbon::now()->format('Ymd');
             $response = $response->withAddedHeader('Content-Disposition', "attachment;filename={$this->name}.csv");
             $response = $response->withAddedHeader('Content-Type', 'text/csv; charset=utf-8');
 

--- a/app/sprinkles/core/src/Sprunje/Sprunje.php
+++ b/app/sprinkles/core/src/Sprunje/Sprunje.php
@@ -190,7 +190,7 @@ abstract class Sprunje
             // Prepare response
             $settings = http_build_query($this->options);
             $date = Carbon::now()->format('Ymd');
-            $response = $response->withAddedHeader('Content-Disposition', "attachment;filename=$date-{$this->name}-$settings.csv");
+            $response = $response->withAddedHeader('Content-Disposition', "attachment;filename={$this->name}.csv");
             $response = $response->withAddedHeader('Content-Type', 'text/csv; charset=utf-8');
 
             return $response->write($result);


### PR DESCRIPTION
Fix for https://github.com/userfrosting/UserFrosting/issues/893
Should prevent file names from exceeding maximum allowed.
- Date is not really necessary as file metadata will have timestamp for creation. 
- Including the sorts/filters really made most file names overwhelming. 