### PR TITLE
More helpful error message in checkEnvironment.php

### DIFF
--- a/app/sprinkles/core/src/Util/CheckEnvironment.php
+++ b/app/sprinkles/core/src/Util/CheckEnvironment.php
@@ -125,6 +125,10 @@ class CheckEnvironment
             $problemsFound = true;
         }
 
+        if ($this->checkDirectories()) {
+            $problemsFound = true;
+        }
+
         if ($this->checkPermissions()) {
             $problemsFound = true;
         }
@@ -258,11 +262,50 @@ class CheckEnvironment
     }
 
     /**
+    * Check that log, cache, and session directories exist.
+    */
+    public function checkDirectories()
+    {
+        $problemsFound = false;
+
+        $directoryPaths = [
+            "log"     => $this->locator->findResource('log://'),
+            "cache"   => $this->locator->findResource('cache://'),
+            "session" => $this->locator->findResource('session://')
+        ];
+
+        foreach ($directoryPaths as $directory => $path) {
+          if ($path == null) {
+            $problemsFound = true;
+            $this->resultsFailed['directory-' . $directory] = [
+                'title'   => "<i class='fa fa-file-o fa-fw'></i> A required directory was not found.",
+                'message' => "Please check that <code>userfrosting/app/$directory</code> exists.",
+                'success' => false
+            ];
+          }
+          else {
+              $this->resultsSuccess['directory-' . $directory] = [
+                  'title'   => "<i class='fa fa-file-o fa-fw'></i> File/directory check passed!",
+                  'message' => "<code>userfrosting/app/$directory</code> exists.",
+                  'success' => true
+              ];
+          }
+      }
+        return $problemsFound;
+  }
+
+    /**
      * Check that log, cache, and session directories are writable, and that other directories are set appropriately for the environment.
      */
     public function checkPermissions()
     {
         $problemsFound = false;
+
+        // Skip this check if the required directories do not exist.
+        if ($this->checkDirectories() == true) {
+          $problemsFound = true;
+        return $problemsFound;
+        }
 
         $shouldBeWriteable = [
             $this->locator->findResource('log://')     => true,
@@ -280,15 +323,6 @@ class CheckEnvironment
 
         // Check for essential files & perms
         foreach ($shouldBeWriteable as $file => $assertWriteable) {
-            $is_dir = false;
-            if (!file_exists($file)) {
-                $problemsFound = true;
-                $this->resultsFailed['file-' . $file] = [
-                    'title'   => "<i class='fa fa-file-o fa-fw'></i> File or directory does not exist.",
-                    'message' => "We could not find the file or directory <code>$file</code>.",
-                    'success' => false
-                ];
-            } else {
                 $writeable = is_writable($file);
                 if ($assertWriteable !== $writeable) {
                     $problemsFound = true;
@@ -311,11 +345,9 @@ class CheckEnvironment
                             . '</b>.',
                         'success' => true
                     ];
-                }
-            }
+              }
         }
-
-        return $problemsFound;
+          return $problemsFound;
     }
 
     /**

--- a/app/sprinkles/core/src/Util/CheckEnvironment.php
+++ b/app/sprinkles/core/src/Util/CheckEnvironment.php
@@ -127,6 +127,8 @@ class CheckEnvironment
 
         if ($this->checkDirectories()) {
             $problemsFound = true;
+        // Skip checkPermissions() if the required directories do not exist.
+        return $problemsFound;
         }
 
         if ($this->checkPermissions()) {
@@ -300,12 +302,6 @@ class CheckEnvironment
     public function checkPermissions()
     {
         $problemsFound = false;
-
-        // Skip this check if the required directories do not exist.
-        if ($this->checkDirectories() == true) {
-          $problemsFound = true;
-        return $problemsFound;
-        }
 
         $shouldBeWriteable = [
             $this->locator->findResource('log://')     => true,

--- a/app/sprinkles/core/src/Util/CheckEnvironment.php
+++ b/app/sprinkles/core/src/Util/CheckEnvironment.php
@@ -127,8 +127,8 @@ class CheckEnvironment
 
         if ($this->checkDirectories()) {
             $problemsFound = true;
-        // Skip checkPermissions() if the required directories do not exist.
-        return $problemsFound;
+            // Skip checkPermissions() if the required directories do not exist.
+            return $problemsFound;
         }
 
         if ($this->checkPermissions()) {
@@ -264,37 +264,37 @@ class CheckEnvironment
     }
 
     /**
-    * Check that log, cache, and session directories exist.
-    */
+     * Check that log, cache, and session directories exist.
+     */
     public function checkDirectories()
     {
         $problemsFound = false;
 
         $directoryPaths = [
-            "logs"     => $this->locator->findResource('log://'),
-            "cache"    => $this->locator->findResource('cache://'),
-            "sessions" => $this->locator->findResource('session://')
+            'logs'     => $this->locator->findResource('log://'),
+            'cache'    => $this->locator->findResource('cache://'),
+            'sessions' => $this->locator->findResource('session://')
         ];
 
         foreach ($directoryPaths as $directory => $path) {
-          if ($path == null) {
-            $problemsFound = true;
-            $this->resultsFailed['directory-' . $directory] = [
+            if ($path == null) {
+                $problemsFound = true;
+                $this->resultsFailed['directory-' . $directory] = [
                 'title'   => "<i class='fa fa-file-o fa-fw'></i> A required directory was not found.",
                 'message' => "Please check that <code>userfrosting/app/$directory</code> exists.",
                 'success' => false
             ];
-          }
-          else {
-              $this->resultsSuccess['directory-' . $directory] = [
+            } else {
+                $this->resultsSuccess['directory-' . $directory] = [
                   'title'   => "<i class='fa fa-file-o fa-fw'></i> File/directory check passed!",
                   'message' => "<code>userfrosting/app/$directory</code> exists.",
                   'success' => true
               ];
-          }
-      }
+            }
+        }
+
         return $problemsFound;
-  }
+    }
 
     /**
      * Check that log, cache, and session directories are writable, and that other directories are set appropriately for the environment.
@@ -319,10 +319,10 @@ class CheckEnvironment
 
         // Check for essential files & perms
         foreach ($shouldBeWriteable as $file => $assertWriteable) {
-                $writeable = is_writable($file);
-                if ($assertWriteable !== $writeable) {
-                    $problemsFound = true;
-                    $this->resultsFailed['file-' . $file] = [
+            $writeable = is_writable($file);
+            if ($assertWriteable !== $writeable) {
+                $problemsFound = true;
+                $this->resultsFailed['file-' . $file] = [
                         'title'   => "<i class='fa fa-file-o fa-fw'></i> Incorrect permissions for file or directory.",
                         'message' => "<code>$file</code> is "
                             . ($writeable ? 'writeable' : 'not writeable')
@@ -333,16 +333,17 @@ class CheckEnvironment
                             . ($assertWriteable ? 'has' : 'does not have') . ' write permissions for this directory.',
                         'success' => false
                     ];
-                } else {
-                    $this->resultsSuccess['file-' . $file] = [
+            } else {
+                $this->resultsSuccess['file-' . $file] = [
                         'title'   => "<i class='fa fa-file-o fa-fw'></i> File/directory check passed!",
                         'message' => "<code>$file</code> exists and is correctly set as <b>"
                             . ($writeable ? 'writeable' : 'not writeable')
                             . '</b>.',
                         'success' => true
                     ];
-              }
+            }
         }
+
         return $problemsFound;
     }
 

--- a/app/sprinkles/core/src/Util/CheckEnvironment.php
+++ b/app/sprinkles/core/src/Util/CheckEnvironment.php
@@ -271,9 +271,9 @@ class CheckEnvironment
         $problemsFound = false;
 
         $directoryPaths = [
-            "log"     => $this->locator->findResource('log://'),
-            "cache"   => $this->locator->findResource('cache://'),
-            "session" => $this->locator->findResource('session://')
+            "logs"     => $this->locator->findResource('log://'),
+            "cache"    => $this->locator->findResource('cache://'),
+            "sessions" => $this->locator->findResource('session://')
         ];
 
         foreach ($directoryPaths as $directory => $path) {
@@ -343,7 +343,7 @@ class CheckEnvironment
                     ];
               }
         }
-          return $problemsFound;
+        return $problemsFound;
     }
 
     /**


### PR DESCRIPTION
Provide helpful error message in situation where `cache` `session` or `logs` is accidentally deleted or moved. 
The existing error was: 
![image](https://user-images.githubusercontent.com/33728190/55663077-1225b100-57e8-11e9-9b79-00adc3d85bca.png)


This adds `checkDirectories` which provides a more helpful error message:
![image](https://user-images.githubusercontent.com/33728190/55663346-e1934680-57ea-11e9-9a65-c2a5c8db2218.png)


Because I was unable to come up with a more creative way to prevent `checkPermissions` from returning the generic error message, that check is skipped until the directories actually exist. 
