### PR TITLE
Respects CSRF_ENABLED environment variable

### DIFF
--- a/app/sprinkles/core/config/default.php
+++ b/app/sprinkles/core/config/default.php
@@ -96,7 +96,7 @@ return [
         * Note : CSRF Middleware should only be disabled for dev or debug purposes.
         */
         'csrf' => [
-            'enabled'          => getenv('CSRF_ENABLED') ?: true,
+            'enabled'          => (getenv('CSRF_ENABLED') !== false) ? getenv('CSRF_ENABLED') : true,
             'name'             => 'csrf',
             'storage_limit'    => 200,
             'strength'         => 16,


### PR DESCRIPTION
The previous statement would evaluate to true for any value of CSRF_ENABLED.
Using the strict comparison operator means if we set the variable to any false-evaluating values other then boolean false (0, '0', '0.0', '' and so on), then CSRF will be disabled.
getenv() evaluates to boolean false if the environment variable is not set, so I know of no simple way to distinguish between the variable being unset, in which case we want to default to enabling CSRF, and it being explicitly set to boolean false.