### PR TITLE
Fix DefaultPermissions.php SQL Error

### DIFF
--- a/app/sprinkles/account/src/Database/Seeds/DefaultPermissions.php
+++ b/app/sprinkles/account/src/Database/Seeds/DefaultPermissions.php
@@ -186,7 +186,7 @@ class DefaultPermissions extends BaseSeed
      * Save permissions
      * @param array $permissions
      */
-    protected function savePermissions(array $permissions)
+    protected function savePermissions(array &$permissions)
     {
         foreach ($permissions as $slug => $permission) {
 


### PR DESCRIPTION
Fixed sql error when running `php bakery seed DefaultPermissions` as noted in issue #981 