### PR TITLE
Fixes UserFrosting#965 - Ignore files that don't end in .php

### DIFF
--- a/app/sprinkles/core/src/Database/Migrator/MigrationLocator.php
+++ b/app/sprinkles/core/src/Database/Migrator/MigrationLocator.php
@@ -54,7 +54,11 @@ class MigrationLocator implements MigrationLocatorInterface
 
         $migrations = [];
         foreach ($migrationFiles as $migrationFile) {
-            $migrations[] = $this->getMigrationDetails($migrationFile);
+            // Note that PSR4 insists that all php files must end in PHP, so ignore all
+            // files that don't end in PHP.
+            if (preg_match('/php$/', $migrationFile)) {
+                $migrations[] = $this->getMigrationDetails($migrationFile);
+            }
         }
 
         return $migrations;

--- a/app/sprinkles/core/tests/Integration/Database/Migrator/MigrationLocatorTest.php
+++ b/app/sprinkles/core/tests/Integration/Database/Migrator/MigrationLocatorTest.php
@@ -90,6 +90,7 @@ class MigrationLocatorTest extends TestCase
             new Resource($resourceStream, $resourceAccountLocation, 'one/CreatePasswordResetsTable.php'),
             new Resource($resourceStream, $resourceAccountLocation, 'two/CreateFlightsTable.php'),
             new Resource($resourceStream, $resourceAccountLocation, 'CreateMainTable.php'),
+            new Resource($resourceStream, $resourceAccountLocation, 'README.md'), // This shoudn't be returned by the migrator
         ]);
 
         // Create a new MigrationLocator instance with our simulated ResourceLocation
@@ -109,7 +110,6 @@ class MigrationLocatorTest extends TestCase
         ];
 
         // Test results match expectations
-        $this->assertCount(8, $results);
         $this->assertEquals($expected, $results);
 
         return $locator;


### PR DESCRIPTION
This ignores any files in Migrations that do not end in .php

It causes problems when scripts, or data, or documentation is
left in the Migrations directory, and the migration task assumes
that they are PHP Classes and crashes.

Signed-Off-By: Rob Thomas <xrobau@gmail.com>