### PR TITLE
migrate:clean bakery command

### DIFF
--- a/app/sprinkles/core/src/Bakery/MigrateCleanCommand.php
+++ b/app/sprinkles/core/src/Bakery/MigrateCleanCommand.php
@@ -31,7 +31,9 @@ class MigrateCleanCommand extends MigrateCommand
     {
         $this->setName('migrate:clean')
              ->setDescription('Remove stale migrations from the database.')
-             ->addOption('database', 'd', InputOption::VALUE_REQUIRED, 'The database connection to use.');
+             ->setHelp('Removes stale migrations, which are simply migration class files that have been removed from the Filesystem. E.g. if you run a migration and then delete the migration class file prior to running `down()` for that migration it becomes stale. If a migration is a dependency of another migration you probably want to try to restore the files instead of running this command to avoid further issues.')
+             ->addOption('database', 'd', InputOption::VALUE_REQUIRED, 'The database connection to use.')
+             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Do not prompt for confirmation.');
     }
 
     /**
@@ -60,11 +62,13 @@ class MigrateCleanCommand extends MigrateCommand
         $stale = $this->getStaleRecords($ran, $available);
 
         if ($stale->count() > 0) {
-            $this->io->section('Stale migrations');
-            $this->io->listing($stale->toArray());
+            if (!$input->getOption('force')) {
+                $this->io->section('Stale migrations');
+                $this->io->listing($stale->toArray());
 
-            if (!$this->io->confirm('Continue and remove stale migrations?', false)) {
-                exit;
+                if (!$this->io->confirm('Continue and remove stale migrations?', false)) {
+                    exit;
+                }
             }
             $this->io->section('Cleaned migrations');
             $this->cleanStaleRecords($stale, $migrator);

--- a/app/sprinkles/core/src/Bakery/MigrateCleanCommand.php
+++ b/app/sprinkles/core/src/Bakery/MigrateCleanCommand.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * UserFrosting (http://www.userfrosting.com)
+ *
+ * @link      https://github.com/userfrosting/UserFrosting
+ * @copyright Copyright (c) 2019 Alexander Weissman
+ * @license   https://github.com/userfrosting/UserFrosting/blob/master/LICENSE.md (MIT License)
+ */
+
+namespace UserFrosting\Sprinkle\Core\Bakery;
+
+use Illuminate\Support\Collection;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * migrate:rollback Bakery Command
+ * Rollback the last migrations ran against the database.
+ *
+ * @author Louis Charette
+ */
+class MigrateCleanCommand extends MigrateCommand
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('migrate:clean')
+             ->setDescription('Clean stale records from migrations database')
+             ->addOption('pretend', 'p', InputOption::VALUE_NONE, 'Run migrations in "dry run" mode.')
+             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force the operation to run when in production.')
+             ->addOption('database', 'd', InputOption::VALUE_REQUIRED, 'The database connection to use.')
+             ->addOption('migration', 'm', InputOption::VALUE_REQUIRED, 'The specific migration to rollback.')
+             ->addOption('steps', 's', InputOption::VALUE_REQUIRED, 'Number of batch to rollback.', 1);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->io->title('Migration clean');
+
+        // Get migrator
+        $migrator = $this->ci->migrator;
+
+        // Set connection to the selected database
+        $migrator->setConnection($input->getOption('database'));
+
+        // Get ran migrations. If repository doesn't exist, there's no ran
+        if (!$migrator->repositoryExists()) {
+            $ran = collect();
+        } else {
+            $ran = $migrator->getRepository()->getMigrations();
+        }
+
+        // Get available migrations
+        $available = $migrator->getAvailableMigrations();
+
+        $stale = $this->getStaleRecords($ran, $available);
+        //    print_r($stale);
+
+        $this->cleanStaleRecords($stale, $migrator);
+
+        // Display ran migrations
+        $this->io->section('Cleaned migrations');
+        if ($ran->count() > 0) {
+        } else {
+            $this->io->note('No installed migrations');
+        }
+    }
+
+    protected function cleanStaleRecords(array $stale, $migrator)
+    {
+        //  print_r($stale);
+        foreach ($stale as $staleFile) {
+            print_r($staleFile);
+            print_r($staleFile['migration']);
+            $migrator->$repository->delete($staleFile['migration']);
+        }
+    }
+
+    /**
+     * Return an array of stale migrations.
+     * A migration is stale if not found in the available stack (class is not in the Filesystem).
+     *
+     * @param Collection $ran       The ran migrations
+     * @param array      $available The available migrations
+     *
+     * @return Collection Collection of stale migration classes.
+     */
+    protected function getStaleRecords(Collection $ran, array $available)
+    {
+        return  $filtered = collect($ran)->filter(function ($migration) use ($available) {
+            return !in_array($migration->migration, $available);
+        })->toArray();
+    }
+}

--- a/app/sprinkles/core/src/Database/Migrator/MigrationDependencyAnalyser.php
+++ b/app/sprinkles/core/src/Database/Migrator/MigrationDependencyAnalyser.php
@@ -210,7 +210,7 @@ class MigrationDependencyAnalyser
 
         // Make sure class exists
         if (!class_exists($migration)) {
-            throw new BadClassNameException("Unable to find the migration class '$migration'.");
+            throw new BadClassNameException("Unable to find the migration class '$migration'. Run 'php bakery migrate:clean' to remove stale migrations.");
         }
 
         // If the `dependencies` property exist and is static, use this one.

--- a/app/sprinkles/core/src/Database/Migrator/Migrator.php
+++ b/app/sprinkles/core/src/Database/Migrator/Migrator.php
@@ -453,7 +453,7 @@ class Migrator
     public function resolve($migrationClassName)
     {
         if (!class_exists($migrationClassName)) {
-            throw new BadClassNameException("Unable to find the migration class '$migrationClassName'.");
+            throw new BadClassNameException("Unable to find the migration class '$migrationClassName'. Run 'php bakery migrate:clean' to remove stale migrations.");
         }
 
         $migration = new $migrationClassName($this->getSchemaBuilder());


### PR DESCRIPTION
This command removes stale migrations from the database. These missing migration classes prevent other `migrate:*` commands from running until the missing class files are either added back to the file system or  manually dropped from the `migrations` table. 

I also added a note about the new command when "Unable to find migration..." error messages are given in two of the `Migrator` classes. 

Issue #1002