### PR TITLE
Fix typos in user creation with initial password

### DIFF
--- a/app/sprinkles/admin/schema/requests/user/create.yaml
+++ b/app/sprinkles/admin/schema/requests/user/create.yaml
@@ -90,7 +90,7 @@ passwordc:
       message: VALIDATE.REQUIRED
     matches:
       domain: client
-      field: value
+      field: password
       label: "&PASSWORD.CONFIRM"
       message: VALIDATE.PASSWORD_MISMATCH
     length:

--- a/app/sprinkles/admin/src/Controller/UserController.php
+++ b/app/sprinkles/admin/src/Controller/UserController.php
@@ -167,7 +167,7 @@ class UserController extends SimpleController
             $passwordRequest = $this->ci->repoPasswordReset->create($user, $config['password_reset.timeouts.create']);
 
             // If the password_mode is manual, do not send an email to set it. Else, send the email.
-            if (!isset($data['value'])) {
+            if ($data['password'] === '') {
                 // Create and send welcome email with password set link
                 $message = new TwigMailMessage($this->ci->view, 'mail/password-create.html.twig');
 
@@ -786,8 +786,8 @@ class UserController extends SimpleController
 
         // Load validation rules
         $schema = new RequestSchema('schema://requests/user/edit-password.yaml');
-        $schema->set('value.validators.length.min', $config['site.password.length.min']);
-        $schema->set('value.validators.length.max', $config['site.password.length.max']);
+        $schema->set('password.validators.length.min', $config['site.password.length.min']);
+        $schema->set('password.validators.length.max', $config['site.password.length.max']);
         $schema->set('passwordc.validators.length.min', $config['site.password.length.min']);
         $schema->set('passwordc.validators.length.max', $config['site.password.length.max']);
         $validator = new JqueryValidationAdapter($schema, $this->ci->translator);


### PR DESCRIPTION
Not sure if I picked the right base branch, let me know :)

This fixes some (I guess) typos in https://github.com/userfrosting/UserFrosting/pull/1017 such that it actually works (on my machine™️).

issue: https://github.com/userfrosting/UserFrosting/pull/764