### PR TITLE
Fix typos in form.fields.hidden

### DIFF
--- a/app/sprinkles/admin/templates/forms/group.html.twig
+++ b/app/sprinkles/admin/templates/forms/group.html.twig
@@ -33,7 +33,7 @@
                 </div>
             </div>
             {% endif %}
-            {% if 'icon' not in fields.hidden %}
+            {% if 'icon' not in form.fields.hidden %}
             <div class="col-sm-12">
                 <div class="form-group iconpicker-container">
                     <label>{{translate("GROUP.ICON")}}</label>
@@ -44,7 +44,7 @@
                 </div>
             </div>
             {% endif %}
-            {% if 'description' not in fields.hidden %}
+            {% if 'description' not in form.fields.hidden %}
             <div class="col-sm-12">
                 <div class="form-group">
                     <label for="input_description">{{translate("DESCRIPTION")}}</label>


### PR DESCRIPTION
Fix typos: missing `form.`  in `form.fields.hidden` for icon and description

Noticed that these two fields were not being hidden despite including them in `form.fields.hidden` in the controller.