### PR TITLE
Fix edit password schema field name

### DIFF
--- a/app/sprinkles/admin/schema/requests/user/edit-password.yaml
+++ b/app/sprinkles/admin/schema/requests/user/edit-password.yaml
@@ -1,5 +1,5 @@
 ---
-value:
+password:
   validators:
     required:
       domain: client
@@ -19,7 +19,7 @@ passwordc:
       message: VALIDATE.REQUIRED
     matches:
       domain: client
-      field: value
+      field: password
       label: "&PASSWORD.CONFIRM"
       message: VALIDATE.PASSWORD_MISMATCH
     length:


### PR DESCRIPTION
The input name in the rendered modal is `password` instead of `value`
See https://github.com/userfrosting/UserFrosting/blob/a8e6711fd5afd0572fc1581950f161b9581a8ffd/app/sprinkles/admin/templates/forms/partials/user-set-password.html.twig#L25