### PR TITLE
Fix direct password edit

### DIFF
--- a/app/sprinkles/admin/src/Controller/UserController.php
+++ b/app/sprinkles/admin/src/Controller/UserController.php
@@ -77,6 +77,10 @@ class UserController extends SimpleController
 
         // Load the request schema
         $schema = new RequestSchema('schema://requests/user/create.yaml');
+        $schema->set('password.validators.length.min', $config['site.password.length.min']);
+        $schema->set('password.validators.length.max', $config['site.password.length.max']);
+        $schema->set('passwordc.validators.length.min', $config['site.password.length.min']);
+        $schema->set('passwordc.validators.length.max', $config['site.password.length.max']);
 
         // Whitelist and set parameter defaults
         $transformer = new RequestDataTransformer($schema);
@@ -621,6 +625,10 @@ class UserController extends SimpleController
 
         // Load validation rules
         $schema = new RequestSchema('schema://requests/user/create.yaml');
+        $schema->set('password.validators.length.min', $config['site.password.length.min']);
+        $schema->set('password.validators.length.max', $config['site.password.length.max']);
+        $schema->set('passwordc.validators.length.min', $config['site.password.length.min']);
+        $schema->set('passwordc.validators.length.max', $config['site.password.length.max']);
         $validator = new JqueryValidationAdapter($schema, $this->ci->translator);
 
         return $this->ci->view->render($response, 'modals/user.html.twig', [
@@ -786,8 +794,8 @@ class UserController extends SimpleController
 
         // Load validation rules
         $schema = new RequestSchema('schema://requests/user/edit-password.yaml');
-        $schema->set('password.validators.length.min', $config['site.password.length.min']);
-        $schema->set('password.validators.length.max', $config['site.password.length.max']);
+        $schema->set('value.validators.length.min', $config['site.password.length.min']);
+        $schema->set('value.validators.length.max', $config['site.password.length.max']);
         $schema->set('passwordc.validators.length.min', $config['site.password.length.min']);
         $schema->set('passwordc.validators.length.max', $config['site.password.length.max']);
         $validator = new JqueryValidationAdapter($schema, $this->ci->translator);

--- a/app/sprinkles/admin/templates/forms/partials/user-set-password.html.twig
+++ b/app/sprinkles/admin/templates/forms/partials/user-set-password.html.twig
@@ -22,7 +22,7 @@
                 <label>{{translate('PASSWORD')}}</label>
                 <div class="input-group">
                     <span class="input-group-addon"><i class="fas fa-key"></i></span>
-                    <input type="password" class="form-control" name="{{ passwordFieldName|default('password') }}" autocomplete="off" value="" placeholder="{{translate('PASSWORD.BETWEEN', {min: 12, max: 50})}}">
+                    <input type="password" class="form-control" name="{{ passwordFieldName|default('password') }}" autocomplete="off" value="" placeholder="{{translate('PASSWORD.BETWEEN', {min: site.password.length.min, max: site.password.length.max})}}">
                 </div>
             </div>
             <div class="form-group">

--- a/app/sprinkles/admin/templates/forms/partials/user-set-password.html.twig
+++ b/app/sprinkles/admin/templates/forms/partials/user-set-password.html.twig
@@ -22,7 +22,7 @@
                 <label>{{translate('PASSWORD')}}</label>
                 <div class="input-group">
                     <span class="input-group-addon"><i class="fas fa-key"></i></span>
-                    <input type="password" class="form-control" name="password" autocomplete="off" value="" placeholder="{{translate('PASSWORD.BETWEEN', {min: 12, max: 50})}}">
+                    <input type="password" class="form-control" name="{{ passwordFieldName|default('password') }}" autocomplete="off" value="" placeholder="{{translate('PASSWORD.BETWEEN', {min: 12, max: 50})}}">
                 </div>
             </div>
             <div class="form-group">

--- a/app/sprinkles/admin/templates/forms/user-set-password.html.twig
+++ b/app/sprinkles/admin/templates/forms/user-set-password.html.twig
@@ -3,7 +3,7 @@
     <div class="js-form-alerts">
     </div>
     <div class="row">
-		{% include "forms/partials/user-set-password.html.twig" %}
+		{% include "forms/partials/user-set-password.html.twig" with {'passwordFieldName':passwordFieldName} %}
     </div>
 	<br>
     <div class="row">

--- a/app/sprinkles/admin/templates/modals/user-set-password.html.twig
+++ b/app/sprinkles/admin/templates/modals/user-set-password.html.twig
@@ -3,5 +3,5 @@
 {% block modal_title %}{{translate("USER.ADMIN.CHANGE_PASSWORD")}}{% endblock %}
 
 {% block modal_body %}
-	  {% include "forms/user-set-password.html.twig" %}
+	  {% include "forms/user-set-password.html.twig" with {'passwordFieldName': 'value'} %}
 {% endblock %}


### PR DESCRIPTION
Bug: editing a users password does not work, it always ends up as invalid because "the passwords don't match".

This fixes that by making the name of the password field flexible:
* 'password' on the user creation form
* 'value' on the edit password form (since that goes through admin's `UserController::updateField`)

this replaces https://github.com/userfrosting/UserFrosting/pull/1034
see also https://github.com/userfrosting/UserFrosting/pull/1030

I now see that the whole thing could've also been fixed by calling the password field `"value"` (and reverting the above PR), but that looks a bit weird IMHO. But let me know what you think!