### PR TITLE
Improve ordering by activity date

### DIFF
--- a/app/sprinkles/admin/src/Sprunje/ActivitySprunje.php
+++ b/app/sprinkles/admin/src/Sprunje/ActivitySprunje.php
@@ -68,7 +68,7 @@ class ActivitySprunje extends Sprunje
 
         return $this;
     }
-    
+
     /**
      * Sort based on user last name.
      *
@@ -83,7 +83,7 @@ class ActivitySprunje extends Sprunje
 
         return $this;
     }
-    
+
     /**
      * Sort based on activity occurred_at.
      *

--- a/app/sprinkles/admin/src/Sprunje/ActivitySprunje.php
+++ b/app/sprinkles/admin/src/Sprunje/ActivitySprunje.php
@@ -83,4 +83,20 @@ class ActivitySprunje extends Sprunje
 
         return $this;
     }
+    
+    /**
+     * Sort based on activity occurred_at.
+     *
+     * @param Builder $query
+     * @param string  $direction
+     *
+     * @return self
+     */
+    protected function sortOccurredAt($query, $direction)
+    {
+        $query->orderBy('activities.occurred_at', $direction)
+              ->orderby('activities.id', $direction);
+
+        return $this;
+    }
 }

--- a/app/sprinkles/admin/src/Sprunje/ActivitySprunje.php
+++ b/app/sprinkles/admin/src/Sprunje/ActivitySprunje.php
@@ -68,7 +68,7 @@ class ActivitySprunje extends Sprunje
 
         return $this;
     }
-
+    
     /**
      * Sort based on user last name.
      *


### PR DESCRIPTION
Some activity logs can occur at the same second, so ordering just by date can show the results unordered. As per @lcharette suggestion, we can order by `occurred_at` AND `id`. That should gives better results.