### PR TITLE
Add AppVeyor config for Windows & SQL Server testing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,89 @@
+## Thanks to Cees-Jan Kiewiet: https://blog.wyrihaximus.net/2016/11/running-php-unit-tests-on-windows-using-appveyor-and-chocolatey/
+## & https://github.com/joomla-framework/database/blob/2.0-dev/.appveyor.yml
+
+## Versioning pattern
+version: '{branch} - Build #{build}'
+
+## Disable unneeded features
+build: off
+deploy: off
+
+## Test against various PHP versions
+environment:
+  matrix:
+    - php_version: "7.1"
+    - php_version: "7.2"
+    - php_version: "7.3"
+
+## Cache composer, chocolatey and php.
+cache:
+  # Composer
+  - '%LOCALAPPDATA%\Composer\files -> composer.lock'
+  - composer.phar
+  # Cache chocolatey packages
+  - C:\ProgramData\chocolatey\bin -> .appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> .appveyor.yml
+  # Cache php install
+  - c:\tools\php -> .appveyor.yml
+
+## Set up environment variables
+init:
+  - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%
+  - SET COMPOSER_NO_INTERACTION=1
+  - SET PHP=1 # This var is connected to PHP install cache
+  - SET ANSICON=121x90 (121x90)
+
+## Install PHP and composer, and run the appropriate composer command
+install:
+  - IF EXIST c:\tools\php (SET PHP=0) # Checks for the PHP install being cached
+  - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_version | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+  # - ps: appveyor-retry cinst -y sqlite
+  - cd c:\tools\php
+  - IF %PHP%==1 copy php.ini-production php.ini /Y
+  - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
+  - IF %PHP%==1 echo extension_dir=ext >> php.ini
+  - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
+  - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
+  - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
+  - IF %PHP%==1 echo extension=php_pdo_sqlite.dll >> php.ini
+  - IF %PHP%==1 echo extension=php_sqlite3.dll >> php.ini
+  #- IF %PHP%==1 echo extension=php_sqlsrv.dll >> php.ini
+  #- IF %PHP%==1 echo extension=php_pdo_sqlsrv.dll >> php.ini
+  - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
+  - appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar
+
+    # install composer dependencies
+  - cd c:\projects\userfrosting
+  - appveyor-retry composer self-update
+  - appveyor-retry composer install --no-progress --prefer-dist
+
+before_test:
+  # - ps: $instanceName = $env:db_version.ToUpper()
+  # - ps: $sqlInstance = "(local)\$instanceName"
+  # - ps: net start "MSSQL`$$instanceName"
+  # - ps: sqlcmd -b -E -S "$sqlInstance" -Q "CREATE DATABASE userfrosting"
+  # - ps: sqlcmd -S "$sqlInstance" -U "sa" -P "Password12!" -i $env:APPVEYOR_BUILD_FOLDER\Tests\Stubs\sqlsrv.sql
+  # - ps: $phpunitConfig = ".travis\phpunit.appveyor_$($env:db_version).xml"
+
+  # Copy sprinkle file
+  - echo F | xcopy app\sprinkles.example.json app\sprinkles.json /y
+
+  # Setup .env
+  - echo UF_MODE="debug" > app/.env
+  - echo DB_DRIVER="sqlite" >> app/.env
+  - echo DB_HOST=127.0.0.1 >> app/.env
+  - echo DB_NAME="userfrosting.db" >> app/.env
+  - echo TEST_DB="default" >> app/.env
+
+  # Install Composer dependencies
+  - appveyor-retry composer update --no-progress --no-interaction
+
+  # Setup UserFrosting
+  - php bakery debug
+  - php bakery build-assets
+  - php bakery migrate
+
+## Run the actual test
+test_script:
+  - cd C:\projects\userfrosting
+  - ps: app\vendor\bin\phpunit


### PR DESCRIPTION
Note this doesn't work in it's current state. It needs to add PHP 7.4 support, which is difficult because it requires a conditional setup for SQLServer. [Error messages](https://ci.appveyor.com/project/userfrosting/userfrosting/build/job/42o7fbgk1v130scu) were also thrown.

Also, see comment in #933:
> Currently AppVeyor support is [unreliable](https://ci.appveyor.com/project/userfrosting/userfrosting/build/job/42o7fbgk1v130scu) and poorly documented. While it's the best bet to get it to work, it requires to install PHP on Windows using Chocolatey which is poorly documented. 

Alternatively, see #1065 for GitHub Action implementation which might be more promising.