### PR TITLE
Make browserify more robust against package issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fixed issue where incompatible NPM packages would be browserified, resulting in install failures.
+
 ## [v4.4.1]
 ### Fixed
 - Fixed issue when compiling assets for produciton ([#1078]).

--- a/build/package.json
+++ b/build/package.json
@@ -1,8 +1,8 @@
 {
   "private": true,
   "dependencies": {
-    "@userfrosting/browserify-dependencies": "^3.0.0",
-    "@userfrosting/gulp-bundle-assets": "^4.0.0",
+    "@userfrosting/browserify-dependencies": "^3.1.0",
+    "@userfrosting/gulp-bundle-assets": "^4.0.1",
     "@userfrosting/merge-package-dependencies": "^1.2.1",
     "@userfrosting/vinyl-fs-vpath": "^1.0.0",
     "bower": "^1.8.8",

--- a/build/tasks/assets-install.js
+++ b/build/tasks/assets-install.js
@@ -95,6 +95,7 @@ export async function assetsInstall() {
             dependencies: Object.keys(pkg.dependencies),
             inputDir: vendorAssetsDir + "node_modules/",
             outputDir: vendorAssetsDir + "browser_modules/",
+            silentFailures: true,
         });
     }
     else {


### PR DESCRIPTION
Fix for issue where incompatible NPM packages would be run through browserify, killing asset install process