### PR TITLE
sign_in_attempt throttler: don't count successful logins

### DIFF
--- a/app/sprinkles/account/src/Controller/AccountController.php
+++ b/app/sprinkles/account/src/Controller/AccountController.php
@@ -396,13 +396,11 @@ class AccountController extends SimpleController
             return $response->withJson([], 429);
         }
 
-        // Log throttleable event
-        $throttler->logEvent('sign_in_attempt', $throttleData);
-
         // If credential is an email address, but email login is not enabled, raise an error.
-        // Note that we do this after logging throttle event, so this error counts towards throttling limit.
+        // Note that this error counts towards the throttling limit.
         if ($isEmail && !$config['site.login.enable_email']) {
             $ms->addMessageTranslated('danger', 'USER_OR_PASS_INVALID');
+            $throttler->logEvent('sign_in_attempt', $throttleData);
 
             return $response->withJson([], 403);
         }
@@ -411,7 +409,13 @@ class AccountController extends SimpleController
         /** @var \UserFrosting\Sprinkle\Account\Authenticate\Authenticator $authenticator */
         $authenticator = $this->ci->authenticator;
 
-        $currentUser = $authenticator->attempt(($isEmail ? 'email' : 'user_name'), $userIdentifier, $data['password'], $data['rememberme']);
+        try {
+            $currentUser = $authenticator->attempt(($isEmail ? 'email' : 'user_name'), $userIdentifier, $data['password'], $data['rememberme']);
+        } catch (\Exception $e) {
+            // only let unsuccessful logins count toward the throttling limit
+            $throttler->logEvent('sign_in_attempt', $throttleData);
+            throw $e;
+        }
 
         $ms->addMessageTranslated('success', 'WELCOME', $currentUser->export());
 

--- a/app/sprinkles/account/src/Controller/AccountController.php
+++ b/app/sprinkles/account/src/Controller/AccountController.php
@@ -414,6 +414,7 @@ class AccountController extends SimpleController
         } catch (\Exception $e) {
             // only let unsuccessful logins count toward the throttling limit
             $throttler->logEvent('sign_in_attempt', $throttleData);
+
             throw $e;
         }
 

--- a/app/sprinkles/account/tests/Integration/Controller/AccountControllerTest.php
+++ b/app/sprinkles/account/tests/Integration/Controller/AccountControllerTest.php
@@ -11,6 +11,7 @@
 namespace UserFrosting\Sprinkle\Account\Tests\Integration\Controller;
 
 use Mockery as m;
+use UserFrosting\Sprinkle\Account\Authenticate\Exception;
 use UserFrosting\Sprinkle\Account\Controller\AccountController;
 use UserFrosting\Sprinkle\Account\Controller\Exception\SpammyRequestException;
 use UserFrosting\Sprinkle\Account\Database\Models\Interfaces\UserInterface;
@@ -616,6 +617,74 @@ class AccountControllerTest extends TestCase
         $ms = $this->ci->alerts;
         $messages = $ms->getAndClearMessages();
         $this->assertSame('danger', end($messages)['type']);
+    }
+
+    /**
+     * @depends testControllerConstructor
+     */
+    public function testloginThrottlerCountsFailedLogins()
+    {
+        // Create fake throttler
+        $throttler = m::mock(Throttler::class);
+        $throttler->shouldReceive('getDelay')->once()->with('sign_in_attempt', ['user_identifier' => 'foo'])->andReturn(0);
+        $throttler->shouldReceive('logEvent')->once()->with('sign_in_attempt', ['user_identifier' => 'foo']);
+        $this->ci->throttler = $throttler;
+
+        // Recreate controller to use fake throttler
+        $controller = $this->getController();
+
+        // Set POST
+        $request = $this->getRequest()->withParsedBody([
+            'user_name'  => 'foo',
+            'password'   => 'bar',
+            'rememberme' => false,
+        ]);
+
+        $this->expectException(Exception\InvalidCredentialsException::class);
+
+        $controller->login($request, $this->getResponse(), []);
+    }
+
+    /**
+     * @depends testControllerConstructor
+     */
+    public function testloginThrottlerDoesntCountSuccessfulLogins()
+    {
+        // Create a test user
+        $testUser = $this->createTestUser();
+
+        // Faker doesn't hash the password. Let's do that now
+        $unhashed = $testUser->password;
+        $testUser->password = Password::hash($testUser->password);
+        $testUser->save();
+
+        // Create fake throttler
+        $throttler = m::mock(Throttler::class);
+        $throttler->shouldReceive('getDelay')->once()->with('sign_in_attempt', ['user_identifier' => $testUser->email])->andReturn(0);
+        $throttler->shouldNotReceive('logEvent');
+        $this->ci->throttler = $throttler;
+
+        // Recreate controller to use fake throttler and test user
+        $controller = $this->getController();
+
+        // Set POST
+        $request = $this->getRequest()->withParsedBody([
+            'user_name'  => $testUser->email,
+            'password'   => $unhashed,
+            'rememberme' => false,
+        ]);
+
+        $result = $controller->login($request, $this->getResponse(), []);
+        $this->assertInstanceOf(\Psr\Http\Message\ResponseInterface::class, $result);
+        // Can't assert the status code or data, as this can be overwrited by sprinkles
+
+        // Test message
+        $ms = $this->ci->alerts;
+        $messages = $ms->getAndClearMessages();
+        $this->assertSame('success', end($messages)['type']);
+
+        // We have to logout the user to avoid problem
+        $this->logoutCurrentUser($testUser);
     }
 
     /**


### PR DESCRIPTION
for https://github.com/userfrosting/UserFrosting/issues/1076

This only changes how attempts are counted, not how the blocking works.

If you got the password wrong often enough to be above the throttle limit, you still can't login, even if you have the correct password now (as that would defeat the whole point).

The big upside is that one can now configure `sign_in_attempts` to be *much* more strict (one could even start blocking after the first attempt).

Tested via throttler mock - let me know if you have better ideas :)