### PR TITLE
Remove whitespace at top of page templates

### DIFF
--- a/app/sprinkles/core/templates/pages/abstract/base.html.twig
+++ b/app/sprinkles/core/templates/pages/abstract/base.html.twig
@@ -1,5 +1,4 @@
 {# This is the base layout template for all pages.  #}
-
 {% block page %}
 <!DOCTYPE html>
 <html lang="{{ currentLocale }}">


### PR DESCRIPTION
Some third-party tools seem to have issues understanding a webpage that contains whitespace before the `DOCTYPE` declaration.