### PR TITLE
Check for null key in Unique::buildTertiaryDictionary

### DIFF
--- a/app/sprinkles/core/src/Database/Relations/Concerns/Unique.php
+++ b/app/sprinkles/core/src/Database/Relations/Concerns/Unique.php
@@ -472,11 +472,13 @@ trait Unique
         foreach ($models as $model) {
             $tertiaryKeyValue = $model->pivot->{$this->tertiaryKey};
 
-            $tertiaryModel = clone $tertiaryModels[$tertiaryKeyValue];
+            if (!is_null($tertiaryKeyValue)) {
+                $tertiaryModel = clone $tertiaryModels[$tertiaryKeyValue];
 
-            $this->transferPivotsToTertiary($model, $tertiaryModel);
+                $this->transferPivotsToTertiary($model, $tertiaryModel);
 
-            $dictionary[$model->getKey()][] = $tertiaryModel;
+                $dictionary[$model->getKey()][] = $tertiaryModel;
+            }
         }
 
         return $dictionary;


### PR DESCRIPTION
Similar to what's done in Unique::buildDictionary, we need to allow for null values in the third column, in which case there is no tertiary model to be added for this row.