### PR TITLE
Deep extend when adding global query params in ufTable

### DIFF
--- a/app/sprinkles/core/assets/userfrosting/js/uf-table.js
+++ b/app/sprinkles/core/assets/userfrosting/js/uf-table.js
@@ -437,7 +437,7 @@
         $.extend(table.config.pager.ajaxObject.data, tableState);
 
         // Merge in any additional parameters
-        $.extend(table.config.pager.ajaxObject.data, this.settings.addParams);
+        $.extend(true, table.config.pager.ajaxObject.data, this.settings.addParams);
 
         return url;
     };
@@ -526,7 +526,7 @@
         delete tableState.size;
 
         // Merge in any additional request parameters
-        $.extend(tableState, this.settings.addParams);
+        $.extend(true, tableState, this.settings.addParams);
 
         // Causes download to begin
         window.location = this.settings.dataUrl + '?' + $.param(tableState);


### PR DESCRIPTION
At the moment if you were to use `addParams` to set a global `filter` or `sort` for a table, it would overwrite all other filters and sorts applied to the table. It doesn't seem like this was a deliberate design choice when `addParams` was introduced in https://github.com/userfrosting/UserFrosting/commit/3159224e942d741b89c40cc8c52108e7e0cf504f. By using a deep extend instead, we can set global filters without overriding any sorts/filters set by the user. It does technically change the behavior, but I don't see a valid use case for the way it currently behaves.