### PR TITLE
Hotfix assets update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unknown]
+
+### Fixed
+- Client-side assets containing glob characters causing crashes when building assets.
+- Fixed issue where merging of package dependencies would show as "undefined", resulting in debugging challenges where there are issues.
+
 ## [v4.4.3]
 
 ### Fixed

--- a/build/package.json
+++ b/build/package.json
@@ -3,10 +3,10 @@
   "dependencies": {
     "@userfrosting/browserify-dependencies": "^3.1.0",
     "@userfrosting/gulp-bundle-assets": "^4.0.1",
-    "@userfrosting/merge-package-dependencies": "^1.2.1",
-    "@userfrosting/vinyl-fs-vpath": "^1.0.0",
+    "@userfrosting/merge-package-dependencies": "^2.1.0",
+    "@userfrosting/vinyl-fs-vpath": "^2.0.0",
     "bower": "^1.8.8",
-    "del": "^5.1.0",
+    "del": "^6.0.0",
     "dotenv": "^8.2.0",
     "esm": "^3.2.25",
     "gulp": "^4.0.2",
@@ -16,6 +16,7 @@
     "gulp-if": "^3.0.0",
     "gulp-prune": "^0.2.0",
     "gulp-rev": "^9.0.0",
+    "gulp-sourcemaps": "^2.6.5",
     "gulp-terser": "^1.2.0",
     "gulplog": "^1.0.0",
     "strip-ansi": "^6.0.0"

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -12,6 +12,7 @@ import { readFileSync, writeFileSync } from "fs";
 import { src } from "@userfrosting/vinyl-fs-vpath";
 import { Logger, vendorAssetsDir, sprinklesDir, sprinkles, sprinkleBundleFile, publicAssetsDir } from "./util.js";
 import gulpIf from "gulp-if";
+import gulpSourcemaps from "gulp-sourcemaps";
 
 /**
  * Compiles frontend assets. Mapped to npm script "uf-bundle".
@@ -135,7 +136,8 @@ export function build() {
 
     // Open stream
     log.info("Starting bundle process proper...");
-    return src({ globs: sources, pathMappings, base: publicAssetsDir, sourcemaps: true })
+    return src({ globs: sources, pathMappings, base: publicAssetsDir })
+        .pipe(gulpSourcemaps.init())
         .pipe(gulpIf(stylesAndScriptsFilter, new Bundler(rawConfig, bundleBuilder, resultsCallback)))
         .pipe(prune(publicAssetsDir))
         .pipe(gulpIf(stylesAndScriptsFilter, gulp.dest(publicAssetsDir, { sourcemaps: "." })))

--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -137,11 +137,14 @@ export function build() {
     // Open stream
     log.info("Starting bundle process proper...");
     return src({ globs: sources, pathMappings, base: publicAssetsDir })
-        .pipe(gulpSourcemaps.init())
+        .pipe(gulpSourcemaps.init({ loadMaps: true }))
         .pipe(gulpIf(stylesAndScriptsFilter, new Bundler(rawConfig, bundleBuilder, resultsCallback)))
         .pipe(prune(publicAssetsDir))
-        .pipe(gulpIf(stylesAndScriptsFilter, gulp.dest(publicAssetsDir, { sourcemaps: "." })))
-        .pipe(gulpIf(everythingElseFilter, gulp.dest(publicAssetsDir)));
+        .pipe(gulpIf(
+            stylesAndScriptsFilter,
+            gulp.dest(publicAssetsDir, { sourcemaps: true }),
+            gulp.dest(publicAssetsDir)
+        ));
 };
 
 /**
@@ -166,12 +169,4 @@ function stylesFilter(fs) {
  */
 function scriptsFilter(fs) {
     return fs.extname === ".js";
-}
-
-/**
- * Used to filter to everything but styles and scripts.
- * @param {import("vinyl").NullFile} fs
- */
-function everythingElseFilter(fs) {
-    return (fs.extname !== ".js") && (fs.extname !== ".css");
 }


### PR DESCRIPTION
From the changelog;

- Client-side assets containing glob characters causing crashes when building assets.
- Fixed issue where merging of package dependencies would show as "undefined", resulting in debugging challenges where there are issues.