### PR TITLE
Force Composer 1.0 for Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -996,3 +996,4 @@ See [http://learn.userfrosting.com/upgrading/40-to-41](Upgrading 4.0.x to 4.1.x 
 [v4.4.1]: https://github.com/userfrosting/UserFrosting/compare/v4.4.0...v4.4.1
 [v4.4.2]: https://github.com/userfrosting/UserFrosting/compare/v4.4.1...v4.4.2
 [v4.4.3]: https://github.com/userfrosting/UserFrosting/compare/v4.4.2...v4.4.3
+[v4.4.4]: https://github.com/userfrosting/UserFrosting/compare/v4.4.3...v4.4.4

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -25,6 +25,8 @@ RUN apt-get install -y \
 # COMPOSER INSTALL
 RUN curl -sSfo /tmp/composer.phar https://getcomposer.org/installer
 RUN php /tmp/composer.phar --install-dir=/usr/local/bin --filename=composer
+# Force Composer Stable Version 1
+RUN composer selfupdate --1
 
 # Install and configure PHP extensions
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \


### PR DESCRIPTION
Some of the UF Dependencies are not yet compatible with Composer 2.x so forcing downgrade to Composer 1.x