### PR TITLE
Update error.html.twig - add container

### DIFF
--- a/app/sprinkles/core/templates/pages/abstract/error.html.twig
+++ b/app/sprinkles/core/templates/pages/abstract/error.html.twig
@@ -9,7 +9,7 @@
     <body {% block body_attributes %}{% endblock %}>
         <!-- Main content -->
         <section class="content">
-          <div class="error-page">
+          <div class="error-page container">
             {% block headline %}<h2 class="headline text-red"><i class="fas fa-terminal" aria-hidden="true"></i></h2>{% endblock %}
 
             <div class="error-content">


### PR DESCRIPTION
The error page content should be in a container so that it doesn't live right up against the edge of the DOM. Adding the `container` class to this div will fix it.