### PR TITLE
Fix PHP7.4+ compatibility

### DIFF
--- a/app/sprinkles/core/src/Database/Models/Model.php
+++ b/app/sprinkles/core/src/Database/Models/Model.php
@@ -70,8 +70,8 @@ abstract class Model extends LaravelModel
     {
         $query = static::whereRaw("LOWER($identifier) = ?", [mb_strtolower($value)]);
 
-        if ($checkDeleted && method_exists($query, 'withTrashed')) {
-            $query = $query->withTrashed();
+        if ($checkDeleted && $query->hasMacro('withTrashed')) {
+           $query = $query->withTrashed();
         }
 
         return $query->first();


### PR DESCRIPTION
PHP 7.4 modified the method_exists behaviour so that it no longer works as required. Alternative is to use is_callable, however this always returns true when __call is present (which it is). Laravel kindly provides a method for checking if a macro exists, so use that instead.

This fixes the exception in #1143 but more work needs to be done for the UI to access soft-deleted items for hard deleting