### PR TITLE
Handle the case where all roles are removed from a user

### DIFF
--- a/app/sprinkles/admin/src/Controller/UserController.php
+++ b/app/sprinkles/admin/src/Controller/UserController.php
@@ -1322,11 +1322,15 @@ class UserController extends SimpleController
         // Get PUT parameters: value
         $put = $request->getParsedBody();
 
-        // Make sure data is part of $_PUT data
+        // Make sure data is part of $_PUT data, default to empty value if sensible, otherwise error
         if (isset($put[$fieldName])) {
             $fieldData = $put[$fieldName];
         } else {
-            throw new BadRequestException();
+            if ($fieldName == 'roles') {
+                $fieldData = [];
+            } else {
+                throw new BadRequestException();
+            }
         }
 
         // Create and validate key -> value pair


### PR DESCRIPTION
When the last role is removed from a user an exception occurs (BadRequest). It is feasible for a user to not have any roles IMO so this provides a default value in the case where all roles are removed (ie only the csrf is sent in the PUT request).  This is a bit of a special case because roles are an array and not a single value (which could be empty) unlike other cases.