### PR TITLE
Fix for FindUniqueTest when class mappings are changed

### DIFF
--- a/app/sprinkles/account/tests/Integration/FindUniqueTest.php
+++ b/app/sprinkles/account/tests/Integration/FindUniqueTest.php
@@ -37,6 +37,9 @@ class FindUniqueTest extends TestCase
         // Setup test database
         $this->setupTestDatabase();
         $this->refreshDatabase();
+
+        $this->ci->classMapper->setClassMapping('user', 'UserFrosting\Sprinkle\Account\Database\Models\User');
+        $this->ci->classMapper->setClassMapping('group', 'UserFrosting\Sprinkle\Account\Database\Models\Group');
     }
 
     /**


### PR DESCRIPTION
`FindUniqueTest` fails in the accounts sprinkle when class mappings are changed for `user` and `group`.