### PR TITLE
StrykeSlammerII v420 patch 1

### DIFF
--- a/app/sprinkles/account/src/Database/Migrations/v420/AddingForeignKeys.php
+++ b/app/sprinkles/account/src/Database/Migrations/v420/AddingForeignKeys.php
@@ -31,7 +31,7 @@ class AddingForeignKeys extends Migration
         '\UserFrosting\Sprinkle\Account\Database\Migrations\v400\PersistencesTable',
         '\UserFrosting\Sprinkle\Account\Database\Migrations\v400\RoleUsersTable',
     ];
-    
+
     /**
      * @var array List of operation to do
      */

--- a/app/sprinkles/account/src/Database/Migrations/v420/AddingForeignKeys.php
+++ b/app/sprinkles/account/src/Database/Migrations/v420/AddingForeignKeys.php
@@ -21,6 +21,17 @@ use UserFrosting\Sprinkle\Core\Database\Migration;
  */
 class AddingForeignKeys extends Migration
 {
+    public static $dependencies = [
+        '\UserFrosting\Sprinkle\Account\Database\Migrations\v400\GroupsTable',
+        '\UserFrosting\Sprinkle\Account\Database\Migrations\v400\UsersTable',
+        '\UserFrosting\Sprinkle\Account\Database\Migrations\v400\VerificationsTable',
+        '\UserFrosting\Sprinkle\Account\Database\Migrations\v400\ActivitiesTable',
+        '\UserFrosting\Sprinkle\Account\Database\Migrations\v400\PasswordResetsTable',
+        '\UserFrosting\Sprinkle\Account\Database\Migrations\v400\PermissionsTable', // which itself requires RolesTable and PermissionsRolesTable
+        '\UserFrosting\Sprinkle\Account\Database\Migrations\v400\PersistencesTable',
+        '\UserFrosting\Sprinkle\Account\Database\Migrations\v400\RoleUsersTable',
+    ];
+    
     /**
      * @var array List of operation to do
      */


### PR DESCRIPTION
At one point I completely tore down my DB and tried rebuilding via migrations, with my own sprinkles in place. Somehow Bakery insisted on running the v420/AddingForeignKeys migration before most of the v400 migrations, so of course it errored and Bakery choked. I've added here the relevant dependencies, and Bakery was able to correctly run all my migrations with these changes.