### PR TITLE
Integrating upstream Whoops issue 752/PR 751

### DIFF
--- a/app/sprinkles/core/src/Error/Renderer/WhoopsRenderer.php
+++ b/app/sprinkles/core/src/Error/Renderer/WhoopsRenderer.php
@@ -22,6 +22,7 @@ use Whoops\Exception\Formatter;
 use Whoops\Exception\Inspector;
 use Whoops\Handler\Handler;
 use Whoops\Handler\PlainTextHandler;
+use Whoops\Run;
 use Whoops\Util\Misc;
 use Whoops\Util\TemplateHelper;
 
@@ -293,6 +294,8 @@ class WhoopsRenderer extends ErrorRenderer
         $vars['tables'] = array_merge($extraTables, $vars['tables']);
 
         $plainTextHandler = new PlainTextHandler();
+        //$plainTextHandler->setRun($this->getRun()); // upstream fix for https://github.com/filp/whoops/issues/752, but here $this->getRun() appears to be null
+        $plainTextHandler->setRun(new Run()); // this works
         $plainTextHandler->setException($this->getException());
         $plainTextHandler->setInspector($this->getInspector());
         $vars['preface'] = "<!--\n\n\n" . $plainTextHandler->generateResponse() . "\n\n\n\n\n\n\n\n\n\n\n-->";


### PR DESCRIPTION
This fixes Integration test WhoopsRendererTest::testRenderWhoopsPage() and related issues with the Whoops error handler.  Creating a new Run instance here, as I can't find an existing one in UF's WhoopsRenderer.
(See related upstream issue https://github.com/filp/whoops/issues/752 and associated PR https://github.com/filp/whoops/pull/751)
(See also UF_ConfigManager issue https://github.com/lcharette/UF_ConfigManager/issues/8#issuecomment-1481604990)
